### PR TITLE
Optimize update_client, lock safety

### DIFF
--- a/nengo_viz/components/netgraph.py
+++ b/nengo_viz/components/netgraph.py
@@ -2,6 +2,7 @@ import time
 import struct
 import os
 import traceback
+import collections
 
 import numpy as np
 import nengo
@@ -20,8 +21,8 @@ class NetGraph(Component):
         self.viz = viz
         self.layout = nengo_viz.layout.Layout(self.viz.model)
         self.config = viz.config
-        self.to_be_expanded = [self.viz.model]
-        self.to_be_sent = []
+        self.to_be_expanded = collections.deque([self.viz.model])
+        self.to_be_sent = collections.deque()
         self.uids = {}
         self.parents = {}
         self.networks_to_search = [self.viz.model]
@@ -175,12 +176,12 @@ class NetGraph(Component):
 
         if len(self.to_be_expanded) > 0:
             self.viz.viz.lock.acquire()
-            network = self.to_be_expanded.pop(0)
+            network = self.to_be_expanded.popleft()
             self.expand_network(network, client)
             self.viz.viz.lock.release()
         else:
             while len(self.to_be_sent) > 0:
-                info = self.to_be_sent.pop(0)
+                info = self.to_be_sent.popleft()
                 client.write(json.dumps(info))
 
     def javascript(self):

--- a/nengo_viz/components/pointer.py
+++ b/nengo_viz/components/pointer.py
@@ -1,8 +1,10 @@
+import struct
+import collections
+
 import nengo
 import nengo.spa
 from nengo.spa.module import Module
 import numpy as np
-import struct
 
 from nengo_viz.components.component import Component, Template
 
@@ -12,7 +14,7 @@ class Pointer(Component):
         super(Pointer, self).__init__(viz, config, uid)
         self.obj = obj
         self.label = viz.viz.get_label(obj)
-        self.data = []
+        self.data = collections.deque()
         self.override_target = None
         self.target = kwargs.get('args', 'default')
         self.vocab_out = obj.outputs[self.target][1]
@@ -59,7 +61,7 @@ class Pointer(Component):
 
     def update_client(self, client):
         while len(self.data) > 0:
-            data = self.data.pop(0)
+            data = self.data.popleft()
             client.write(data, binary=False)
 
     def javascript(self):

--- a/nengo_viz/components/raster.py
+++ b/nengo_viz/components/raster.py
@@ -1,6 +1,8 @@
+import struct
+import collections
+
 import nengo
 import numpy as np
-import struct
 
 from nengo_viz.components.component import Component, Template
 
@@ -9,7 +11,7 @@ class Raster(Component):
     def __init__(self, viz, config, uid, obj, n_neurons=None):
         super(Raster, self).__init__(viz, config, uid)
         self.obj = obj.neurons
-        self.data = []
+        self.data = collections.deque()
         self.label = viz.viz.get_label(obj)
         self.max_neurons = self.obj.size_out
         if n_neurons is None:
@@ -32,7 +34,7 @@ class Raster(Component):
 
     def update_client(self, client):
         while len(self.data) > 0:
-            data = self.data.pop(0)
+            data = self.data.popleft()
             client.write(data, binary=True)
 
     def javascript(self):

--- a/nengo_viz/components/value.py
+++ b/nengo_viz/components/value.py
@@ -28,9 +28,9 @@ class Value(Component):
         self.data.append(self.struct.pack(t, *x))
 
     def update_client(self, client):
-        while len(self.data) > 0:
-            data = self.data.pop(0)
-            client.write(data, binary=True)
+        for item in self.data:
+            client.write(item, binary=True)
+        self.data = []
 
     def javascript(self):
         info = dict(uid=self.uid, n_lines=self.n_lines, label=self.label)

--- a/nengo_viz/components/value.py
+++ b/nengo_viz/components/value.py
@@ -1,6 +1,7 @@
 import nengo
 import numpy as np
 import struct
+import collections
 
 from nengo_viz.components.component import Component, Template
 
@@ -10,7 +11,7 @@ class Value(Component):
         super(Value, self).__init__(viz, config, uid)
         self.obj = obj
         self.label = viz.viz.get_label(obj)
-        self.data = []
+        self.data = collections.deque()
         self.n_lines = obj.size_out
         self.struct = struct.Struct('<%df' % (1 + self.n_lines))
 
@@ -28,9 +29,9 @@ class Value(Component):
         self.data.append(self.struct.pack(t, *x))
 
     def update_client(self, client):
-        for item in self.data:
+        while len(self.data) > 0:
+            item = self.data.popleft()
             client.write(item, binary=True)
-        self.data = []
 
     def javascript(self):
         info = dict(uid=self.uid, n_lines=self.n_lines, label=self.label)

--- a/nengo_viz/components/value.py
+++ b/nengo_viz/components/value.py
@@ -1,7 +1,8 @@
-import nengo
-import numpy as np
 import struct
 import collections
+
+import nengo
+import numpy as np
 
 from nengo_viz.components.component import Component, Template
 

--- a/nengo_viz/components/xyvalue.py
+++ b/nengo_viz/components/xyvalue.py
@@ -1,6 +1,8 @@
+import struct
+import collections
+
 import nengo
 import numpy as np
-import struct
 
 from nengo_viz.components.component import Component, Template
 
@@ -10,7 +12,7 @@ class XYValue(Component):
         super(XYValue, self).__init__(viz, config, uid)
         self.obj = obj
         self.label = viz.viz.get_label(obj)
-        self.data = []
+        self.data = collections.deque()
         self.n_lines = obj.size_out
         self.struct = struct.Struct('<%df' % (1 + self.n_lines))
 
@@ -29,7 +31,7 @@ class XYValue(Component):
 
     def update_client(self, client):
         while len(self.data) > 0:
-            data = self.data.pop(0)
+            data = self.data.popleft()
             client.write(data, binary=True)
 
     def javascript(self):


### PR DESCRIPTION
Popping the first item repeatedly is O(n^2). (http://stackoverflow.com/questions/195625/what-is-the-time-complexity-of-popping-elements-from-list-in-python) This change makes `update_client` O(n).

Also made the lock safer with a context-manager. Previously, an exception in between would have caused a deadlock.