### PR TITLE
Fixed bug where maxy or miny ignored if zero

### DIFF
--- a/nengo_viz/static/viz_value.js
+++ b/nengo_viz/static/viz_value.js
@@ -27,9 +27,7 @@ VIZ.Value = function(parent, sim, args) {
     /** scales for mapping x and y values to pixels */
     this.scale_x = d3.scale.linear();
     this.scale_y = d3.scale.linear();
-    var miny = (args.miny !== null) ? args.miny : -1;
-    var maxy = (args.maxy !== null) ? args.maxy : 1;
-    this.scale_y.domain([miny, maxy]);
+    this.scale_y.domain([args.miny, args.maxy]);
 
     /** spacing between the graph and the outside edges (in pixels) */
     this.margin_top = 30;

--- a/nengo_viz/static/viz_value.js
+++ b/nengo_viz/static/viz_value.js
@@ -27,8 +27,10 @@ VIZ.Value = function(parent, sim, args) {
     /** scales for mapping x and y values to pixels */
     this.scale_x = d3.scale.linear();
     this.scale_y = d3.scale.linear();
-    this.scale_y.domain([args.miny || -1, args.maxy || 1]);
-    
+    var miny = (args.miny !== null) ? args.miny : -1;
+    var maxy = (args.maxy !== null) ? args.maxy : 1;
+    this.scale_y.domain([miny, maxy]);
+
     /** spacing between the graph and the outside edges (in pixels) */
     this.margin_top = 30;
     this.margin_bottom = 40;


### PR DESCRIPTION
Since we were "or"-ing together values to determine the defaults,
the default value would be used if the inputs were zero, since
zero evaluates as false. Now checking whether they're `null`.