### PR TITLE
Server shutdown command

### DIFF
--- a/nengo_viz/server.py
+++ b/nengo_viz/server.py
@@ -21,6 +21,10 @@ class Server(swi.SimpleWebInterface):
         icon = pkgutil.get_data('nengo_viz', 'static/favicon.ico')
         return ('image/ico', icon)
 
+    def swi_shutdown(self):
+        Server.viz.shutdown()
+        Server.shutdown()
+
     def swi(self):
         """Handles http://host:port/ by giving the main page"""
         # create a new simulator

--- a/nengo_viz/server.py
+++ b/nengo_viz/server.py
@@ -22,8 +22,9 @@ class Server(swi.SimpleWebInterface):
         return ('image/ico', icon)
 
     def swi_shutdown(self):
-        Server.viz.shutdown()
-        Server.shutdown()
+        self.viz.cleanup()  # cleanup viz threads
+        self.stop()         # stop handling requests
+        return "Shutting Down"
 
     def swi(self):
         """Handles http://host:port/ by giving the main page"""

--- a/nengo_viz/swi.py
+++ b/nengo_viz/swi.py
@@ -74,7 +74,6 @@ class SimpleWebInterface(BaseHTTPServer.BaseHTTPRequestHandler):
     server_version = 'SimpleWebInterface/2.0'
     serve_files = []
     serve_dirs = []
-    shutdown_flag = False
 
     pending_headers = None
     testing_user = None
@@ -371,10 +370,6 @@ class SimpleWebInterface(BaseHTTPServer.BaseHTTPRequestHandler):
             server = BaseHTTPServer.HTTPServer((addr, port), cls)
 
         cls._stopped.clear()
-        cls._runner(server, asynch)
-
-    @classmethod
-    def _runner(cls, server, asynch):
         try:
             while not cls._stopped.is_set():
                 server.handle_request()

--- a/nengo_viz/viz.py
+++ b/nengo_viz/viz.py
@@ -179,11 +179,12 @@ class Viz(object):
             uid = repr(obj)
         return uid
 
-    def start(self, port=8080, browser=True, separate_thread=False):
+    def start(self, port=8080, browser=True):
         """Start the web server"""
         nengo_viz.server.Server.viz = self
-        return nengo_viz.server.Server.start(port=port, browser=browser,
-                                             separate_thread=separate_thread)
+        # asynch must be true to handle websockets
+        return nengo_viz.server.Server.start(
+            port=port, browser=browser, asynch=True)
 
     def create_sim(self):
         """Create a new Simulator with this configuration"""
@@ -191,6 +192,6 @@ class Viz(object):
         self.vizsims.append(vizsim)
         return vizsim
 
-    def shutdown(self):
+    def cleanup(self):
         for vizsim in self.vizsims:
             vizsim.finish()

--- a/nengo_viz/viz.py
+++ b/nengo_viz/viz.py
@@ -84,6 +84,8 @@ class VizSim(object):
 class Viz(object):
     """The master visualization organizer set up for a particular model."""
     def __init__(self, filename, model=None, locals=None):
+        self.vizsims = []
+
         if locals is None:
             locals = {}
             with open(filename) as f:
@@ -184,4 +186,10 @@ class Viz(object):
 
     def create_sim(self):
         """Create a new Simulator with this configuration"""
-        return VizSim(self)
+        vizsim = VizSim(self)
+        vizsims.append(vizsim)
+        return vizsim
+
+    def shutdown(self):
+        for vizsim in self.vizsims:
+            vizsim.finish()

--- a/nengo_viz/viz.py
+++ b/nengo_viz/viz.py
@@ -179,15 +179,16 @@ class Viz(object):
             uid = repr(obj)
         return uid
 
-    def start(self, port=8080, browser=True):
+    def start(self, port=8080, browser=True, separate_thread=False):
         """Start the web server"""
         nengo_viz.server.Server.viz = self
-        nengo_viz.server.Server.start(port=port, browser=browser)
+        return nengo_viz.server.Server.start(port=port, browser=browser,
+                                             separate_thread=separate_thread)
 
     def create_sim(self):
         """Create a new Simulator with this configuration"""
         vizsim = VizSim(self)
-        vizsims.append(vizsim)
+        self.vizsims.append(vizsim)
         return vizsim
 
     def shutdown(self):


### PR DESCRIPTION
Tests need to be able to shutdown the server in between different models.

Current solution is a little hacky, but the best we could come up with. It requires an additional request after the /shutdown in order to flush out the polling connections. Ports also need to be changed after each shutdown, because resources are not properly cleaned up for some unknown reason.