### PR TITLE
Fix for obj.size_out not being an int in some numpy

### DIFF
--- a/nengo_viz/components/netgraph.py
+++ b/nengo_viz/components/netgraph.py
@@ -187,7 +187,7 @@ class NetGraph(Component):
         if type == 'node' and obj.output is None:
             info['passthrough'] = True
         if type == 'ens' or type == 'node':
-            info['dimensions'] = obj.size_out
+            info['dimensions'] = int(obj.size_out)
 
         if nengo_viz.components.pointer.Pointer.can_apply(obj):
             info['allow_pointer_plot'] = True


### PR DESCRIPTION
In some numpy versions, the object returned by Node.size_out is a zero-dimensional array, rather than an int.  This causes problems when serializing, so we need to cast it to an int just in case.