### PR TITLE
Fixed bug in reload re:iteritems

### DIFF
--- a/nengo_viz/components/netgraph.py
+++ b/nengo_viz/components/netgraph.py
@@ -60,7 +60,7 @@ class NetGraph(Component):
         # for Nodes, Ensembles, and Networks, this means to find the item
         # with the same uid.  For Connections, we don't really have a uid,
         # so we use the uids of the pre and post objects.
-        for uid, old_item in nengo.utils.compat.iteritems(self.uids):
+        for uid, old_item in nengo.utils.compat.iteritems(dict(self.uids)):
             try:
                 new_item = eval(uid, locals)
             except:


### PR DESCRIPTION
The switchfrom .items() to nengo.utils.compat.iteritems() wasn't
tested well enough here.  The loop changes the dictionary, and
iteritems() really doesn't like that.  This wasn't a problem with
the .items() approach, since it's only ever changing the item
it's on in the loop.  The fix here is to duplicate the dictionary.