### PR TITLE
Fixed subnetwork expansion after collapse

### DIFF
--- a/nengo_viz/components/netgraph.py
+++ b/nengo_viz/components/netgraph.py
@@ -208,6 +208,14 @@ class NetGraph(Component):
     def act_collapse(self, uid):
         net = self.uids[uid]
         self.config[net].expanded = False
+        for ens in net.ensembles:
+            del self.uids[self.viz.viz.get_uid(ens)]
+        for net in net.networks:
+            del self.uids[self.viz.viz.get_uid(net)]
+        for node in net.nodes:
+            del self.uids[self.viz.viz.get_uid(node)]
+        for conn in net.connections:
+            del self.uids[self.viz.viz.get_uid(conn)]
         self.modified_config()
 
     def act_pan(self, x, y):


### PR DESCRIPTION
Right now if you collapse a sub-network and then re-expand it, the internal items do not re-appear.

This bug was introduced by the reload system, since it tries to avoid re-creating things that already exist, but when collapsing a network it doesn't realize that those items no longer exist on the client.