### PR TITLE
Tiny cleanup to websocket loop

### DIFF
--- a/nengo_viz/server.py
+++ b/nengo_viz/server.py
@@ -52,8 +52,7 @@ class Server(swi.SimpleWebInterface):
         try:
             while True:
                 if viz_sim.finished:
-                    component.finish()
-                    return
+                    break
                 if viz_sim.uids[uid] != component:
                     component.finish()
                     component = viz_sim.uids[uid]


### PR DESCRIPTION
Follows up on @hunse 's comments in #188 that were missed before it was merged.

Basically just removes a redundant ```component.finished()``` and uses a ```break``` instead of a ```return```.