### PR TITLE
Added 'nengo_viz' script to start the visualizer

### DIFF
--- a/nengo_viz/__init__.py
+++ b/nengo_viz/__init__.py
@@ -1,3 +1,4 @@
 from .viz import Viz
 from .version import version as __version__
 from .namefinder import NameFinder
+from .main import main

--- a/nengo_viz/examples/default.py
+++ b/nengo_viz/examples/default.py
@@ -1,0 +1,7 @@
+import nengo
+
+model = nengo.Network()
+with model:
+    stim = nengo.Node([0])
+    a = nengo.Ensemble(n_neurons=50, dimensions=1)
+    nengo.Connection(stim, a)

--- a/nengo_viz/main.py
+++ b/nengo_viz/main.py
@@ -1,0 +1,21 @@
+import argparse
+
+import nengo_viz
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-p', '--password', dest='password', metavar='PASS',
+        help='password for remote access')
+    parser.add_argument(
+        '-P', '--port', dest='port', metavar='PORT',
+        default=8080, type=int, help='port to run server on')
+    parser.add_argument(
+        'filename', nargs='?', type=str, help='initial file to load')
+    args = parser.parse_args()
+
+    viz = nengo_viz.Viz(filename=args.filename)
+    viz.start(port=args.port, password=args.password)
+
+if __name__ == '__main__':
+    main()

--- a/nengo_viz/server.py
+++ b/nengo_viz/server.py
@@ -23,7 +23,7 @@ class Server(swi.SimpleWebInterface):
         d = unquote(dir)
         ex_tag = '//examples//'
         if d == '.':
-            r.append('<li class="directory collapsed">'
+            r.append('<li class="directory collapsed examples_dir">'
                      '<a href="#" rel="%s">%s</a></li>' % (ex_tag, ex_tag))
             path = '.'
         elif d.startswith(ex_tag):

--- a/nengo_viz/server.py
+++ b/nengo_viz/server.py
@@ -22,9 +22,10 @@ class Server(swi.SimpleWebInterface):
         r = ['<ul class="jqueryFileTree" style="display: none;">']
         d = unquote(dir)
         ex_tag = '//examples//'
+        ex_html = '<em>built-in examples</em>'
         if d == '.':
             r.append('<li class="directory collapsed examples_dir">'
-                     '<a href="#" rel="%s">%s</a></li>' % (ex_tag, ex_tag))
+                     '<a href="#" rel="%s">%s</a></li>' % (ex_tag, ex_html))
             path = '.'
         elif d.startswith(ex_tag):
             path = os.path.join(nengo_viz.__path__[0],

--- a/nengo_viz/server.py
+++ b/nengo_viz/server.py
@@ -18,18 +18,31 @@ class Server(swi.SimpleWebInterface):
     """Web server interface to nengo_viz"""
 
     def swi_browse(self, dir):
-        self.script_path = '.'
         if self.user is None: return
         r = ['<ul class="jqueryFileTree" style="display: none;">']
         d = unquote(dir)
-        for f in sorted(os.listdir(os.path.join(self.script_path, d))):
-            ff = os.path.relpath(os.path.join(self.script_path, d,f), self.script_path)
-            if os.path.isdir(os.path.join(self.script_path, d, ff)):
-                r.append('<li class="directory collapsed"><a href="#" rel="%s/">%s</a></li>' % (ff,f))
+        ex_tag = '//examples//'
+        if d == '.':
+            r.append('<li class="directory collapsed">'
+                     '<a href="#" rel="%s">%s</a></li>' % (ex_tag, ex_tag))
+            path = '.'
+        elif d.startswith(ex_tag):
+            path = os.path.join(nengo_viz.__path__[0], 
+                                'examples', d[len(ex_tag):])
+        else:
+            path = os.path.join('.', d)
+
+        for f in sorted(os.listdir(path)):
+            ff = os.path.relpath(os.path.join(path, f), '.')
+            ff = os.path.join(path, f)
+            if os.path.isdir(os.path.join(path, f)):
+                r.append('<li class="directory collapsed">'
+                         '<a href="#" rel="%s/">%s</a></li>' % (ff,f))
             else:
                 e = os.path.splitext(f)[1][1:] # get .ext and remove dot
                 if e == 'py':
-                    r.append('<li class="file ext_%s"><a href="#" rel="%s">%s</a></li>' % (e,ff,f))
+                    r.append('<li class="file ext_%s">'
+                             '<a href="#" rel="%s">%s</a></li>' % (e,ff,f))
         r.append('</ul>')
         return ''.join(r)
 

--- a/nengo_viz/server.py
+++ b/nengo_viz/server.py
@@ -27,7 +27,7 @@ class Server(swi.SimpleWebInterface):
                      '<a href="#" rel="%s">%s</a></li>' % (ex_tag, ex_tag))
             path = '.'
         elif d.startswith(ex_tag):
-            path = os.path.join(nengo_viz.__path__[0], 
+            path = os.path.join(nengo_viz.__path__[0],
                                 'examples', d[len(ex_tag):])
         else:
             path = os.path.join('.', d)
@@ -59,7 +59,7 @@ class Server(swi.SimpleWebInterface):
 
     def create_login_form(self):
         if self.attempted_login:
-            message = 'Invalid password.  Try again.'
+            message = 'Invalid password. Try again.'
         else:
             message = 'Enter the password:'
         return """<form action="/" method=GET>%s<br>

--- a/nengo_viz/server.py
+++ b/nengo_viz/server.py
@@ -44,8 +44,22 @@ class Server(swi.SimpleWebInterface):
         icon = pkgutil.get_data('nengo_viz', 'static/favicon.ico')
         return ('image/ico', icon)
 
+    def create_login_form(self):
+        if self.attempted_login:
+            message = 'Invalid password.  Try again.'
+        else:
+            message = 'Enter the password:'
+        return """<form action="/" method=GET>%s<br>
+            <input type=hidden name=swi_id value=''>
+            <input type=password name=swi_pwd>
+            <input type=submit value="Log In">
+            </form>""" % message
+
     def swi(self):
         """Handles http://host:port/ by giving the main page"""
+        if self.user is None:
+            return self.create_login_form()
+
         # create a new simulator
         viz_sim = self.viz.create_sim()
 

--- a/nengo_viz/static/viz_top_toolbar.css
+++ b/nengo_viz/static/viz_top_toolbar.css
@@ -56,6 +56,10 @@
     background: #666;
 }
 
+#filebrowser li.examples_dir {
+    background-color: #aaeeff;
+}
+
 #global_config_menu {
     background: purple;
     height: 20em;

--- a/nengo_viz/static/viz_top_toolbar.css
+++ b/nengo_viz/static/viz_top_toolbar.css
@@ -57,7 +57,7 @@
 }
 
 #filebrowser li.examples_dir {
-    background-color: #aaeeff;
+    background-color: #ccc;
 }
 
 #global_config_menu {

--- a/nengo_viz/viz.py
+++ b/nengo_viz/viz.py
@@ -123,18 +123,18 @@ class Viz(object):
         self.config_save_period = 2.0  # minimum time between saves
 
         if filename is None:
-            filename = os.path.join(nengo_viz.__path__[0], 
+            filename = os.path.join(nengo_viz.__path__[0],
                                     'examples',
                                     'default.py')
 
         self.load(filename, model, locals)
 
     def load(self, filename, model=None, locals=None):
+        filename = os.path.relpath(filename)
         if locals is None:
             locals = {}
             locals['nengo_viz'] = nengo_viz
             locals['__file__'] = filename
-
 
             with open(filename) as f:
                 code = f.read()

--- a/nengo_viz/viz.py
+++ b/nengo_viz/viz.py
@@ -262,11 +262,16 @@ class Viz(object):
             uid = repr(obj)
         return uid
 
-    def start(self, port=8080, browser=True):
+    def start(self, port=8080, browser=True, password=None):
         """Start the web server"""
         nengo_viz.server.Server.viz = self
         print("Starting nengo_viz server at http://localhost:%d" % port)
-        nengo_viz.server.Server.start(port=port, browser=browser)
+        if password is not None:
+            nengo_viz.server.Server.add_user('', password)
+            addr = ''
+        else:
+            addr = 'localhost'
+        nengo_viz.server.Server.start(port=port, browser=browser, addr=addr)
 
     def create_sim(self):
         """Create a new Simulator with this configuration"""

--- a/nengo_viz/viz.py
+++ b/nengo_viz/viz.py
@@ -121,6 +121,12 @@ class Viz(object):
         self.viz_sims = []
 
         self.config_save_period = 2.0  # minimum time between saves
+
+        if filename is None:
+            filename = os.path.join(nengo_viz.__path__[0], 
+                                    'examples',
+                                    'default.py')
+
         self.load(filename, model, locals)
 
     def load(self, filename, model=None, locals=None):

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,11 @@ setup(
     author_email="celiasmith@uwaterloo.ca",
     packages=find_packages(),
     include_package_data=True,
+    entry_points={
+        'console_scripts': [
+            'nengo_viz = nengo_viz:main',
+        ]
+    },
     scripts=[],
     url="https://github.com/nengo/nengo_viz",
     license="https://github.com/nengo/nengo_viz/blob/master/LICENSE.md",


### PR DESCRIPTION
This should act like nengo_gui, in that you can specify a file to open, otherwise it will open a default.py file.

One change from nengo_gui is that the file browser shows files from where you ran the script, and in addition it also shows the built-in examples folder.  This way people have access to the built-in examples as well as a more typical file browsing in their local folders.