### PR TITLE
Embedded visualization in IPython notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ target/
 
 # nengo_viz specific
 *.py.cfg
+.ipynb_checkpoints
 
 # Vagrant
 .vagrant

--- a/examples/net.ipynb
+++ b/examples/net.ipynb
@@ -1,0 +1,62 @@
+{
+ "metadata": {
+  "name": "",
+  "signature": "sha256:449f5777c8db5b6d5daf37b3d65fc3848ca984f8862ebb50760a896deda5adea"
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "import numpy as np\n",
+      "import nengo\n",
+      "\n",
+      "model = nengo.Network()\n",
+      "with model:\n",
+      "    stimulus_A = nengo.Node([1], label='stim A')\n",
+      "    stimulus_B = nengo.Node(lambda t: np.sin(2*np.pi*t))\n",
+      "    ens = nengo.Ensemble(n_neurons=1000, dimensions=2)\n",
+      "    result = nengo.Ensemble(n_neurons=50, dimensions=1)\n",
+      "    nengo.Connection(stimulus_A, ens[0])\n",
+      "    nengo.Connection(stimulus_B, ens[1])\n",
+      "    nengo.Connection(ens, result, function=lambda x: x[0] * x[1],\n",
+      "                     synapse=0.01)\n",
+      "\n",
+      "    with nengo.Network(label='subnet') as subnet:\n",
+      "        a = nengo.Ensemble(100, 1)\n",
+      "        b = nengo.Ensemble(100, 1)\n",
+      "        nengo.Connection(a, b)\n",
+      "        nengo.Connection(b, b)\n",
+      "\n",
+      "        with nengo.Network() as subsubnet:\n",
+      "            c = nengo.Ensemble(100, 1)\n",
+      "            d = nengo.Ensemble(100, 1)\n",
+      "            nengo.Connection(c, d)\n",
+      "        nengo.Connection(b, c)\n",
+      "        nengo.Connection(d, a)\n",
+      "    nengo.Connection(result, a)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "from nengo_viz.ipython import IPythonViz\n",
+      "IPythonViz(model)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}

--- a/nengo_viz/components/netgraph.py
+++ b/nengo_viz/components/netgraph.py
@@ -27,15 +27,21 @@ class NetGraph(Component):
         self.parents = {}
         self.networks_to_search = [self.viz.model]
         self.initialized_pan_and_zoom = False
-        self.last_modify_time = os.path.getmtime(self.viz.viz.filename)
+        try:
+            self.last_modify_time = os.path.getmtime(self.viz.viz.filename)
+        except:
+            self.last_modify_time = None;
         self.last_reload_check = time.time()
 
     def check_for_reload(self):
-        t = os.path.getmtime(self.viz.viz.filename)
+        try:
+            t = os.path.getmtime(self.viz.viz.filename)
 
-        if self.last_modify_time < t:
-            self.reload()
-            self.last_modify_time = t
+            if self.last_modify_time < t:
+                self.reload()
+                self.last_modify_time = t
+        except:
+            pass
 
     def reload(self):
         locals = {}

--- a/nengo_viz/components/sim_control.py
+++ b/nengo_viz/components/sim_control.py
@@ -125,8 +125,6 @@ class SimControl(Component):
                 os.remove(self.viz.viz.filename + '.cfg')
             self.viz.viz.load(self.viz.viz.filename)
             self.reload = True
-        else:
-            print(msg)
 
 class SimControlTemplate(Template):
     cls = SimControl

--- a/nengo_viz/components/sim_control.py
+++ b/nengo_viz/components/sim_control.py
@@ -5,6 +5,7 @@ import traceback
 import numpy as np
 import nengo
 import os
+import os.path
 import json
 
 from nengo_viz.components.component import Component, Template
@@ -121,9 +122,12 @@ class SimControl(Component):
             except:
                 traceback.print_exc()
         elif msg == 'reset':
-            if os.path.isfile(self.viz.viz.filename + '.cfg') :
-                os.remove(self.viz.viz.filename + '.cfg')
-            self.viz.viz.load(self.viz.viz.filename)
+            if os.path.isfile(self.viz.viz.config_name()) :
+                os.remove(self.viz.viz.config_name())
+            self.viz.viz.config = self.viz.viz.load_config()
+            self.viz.viz.load(
+                self.viz.viz.filename, self.viz.viz.model,
+                self.viz.viz.orig_locals)
             self.reload = True
 
 class SimControlTemplate(Template):

--- a/nengo_viz/ipython.py
+++ b/nengo_viz/ipython.py
@@ -56,11 +56,12 @@ class IPythonViz(object):
     def start_server(cls, cfg, model):
         name = model.label if model.label is not None else ''
         viz = nengo_viz.Viz(
-            name, cfg=cfg, model=model, locals=get_ipython().user_ns)
+            name, cfg=cfg, model=model, locals=get_ipython().user_ns,
+            interactive=False)
         server = viz.prepare_server(port=0, browser=False)
         server_thread = threading.Thread(
             target=viz.begin_lifecycle,
-            kwargs={'server': server, 'interactive': False})
+            kwargs={'server': server})
         server_thread.start()
         cls.servers[cfg] = server
         cls.threads[cfg] = server_thread

--- a/nengo_viz/ipython.py
+++ b/nengo_viz/ipython.py
@@ -1,54 +1,99 @@
-import nengo_viz
-from IPython.display import display, HTML
+import atexit
 import socket
-import tempfile
 import threading
+import time
+import urllib2
 import uuid
+import weakref
+
+from IPython import get_ipython
+from IPython.display import display, HTML
+
+import nengo_viz
 
 
 class IPythonViz(object):
-    def __init__(self, model, height=600):
+    servers = weakref.WeakValueDictionary()
+    threads = weakref.WeakValueDictionary()
+    configs = set()
+
+    host = 'localhost'
+
+    def __init__(self, model, cfg=None, height=600):
         nengo_viz.server.Server.log_file = None
 
         self.height = height
 
         self._started = False
 
-        self.cfg = tempfile.NamedTemporaryFile()
-        self.viz = nengo_viz.Viz(
-            self.cfg.name, model=model, locals=get_ipython().user_ns)
-        server = self.viz.prepare_server(port=0, browser=False)
+        if cfg is None:
+            cfg = get_ipython().mktempfile()
 
-        self.host = 'localhost'
+        self._server_thread, server = self.get_server(cfg, model)
         self.port = server.server_port
 
-        self._server_thread = threading.Thread(
-            target=self.viz.begin_lifecycle,
+        self.url = self.get_url(self.host, self.port)
+
+
+    @staticmethod
+    def get_url(host, port, action=None):
+        url = 'http://{host}:{port}'.format(host=host, port=port)
+        if action is not None:
+            url += '/' + action
+        return url
+
+    @classmethod
+    def get_server(cls, cfg, model):
+        server_thread = cls.threads.get(cfg, None)
+        server = cls.servers.get(cfg, None)
+        existent = server_thread is not None and server is not None
+        if existent and server_thread.is_alive():
+            return server_thread, server
+        else:
+            return cls.start_server(cfg, model)
+
+    @classmethod
+    def start_server(cls, cfg, model):
+        name = model.label if model.label is not None else ''
+        viz = nengo_viz.Viz(
+            name, cfg=cfg, model=model, locals=get_ipython().user_ns)
+        server = viz.prepare_server(port=0, browser=False)
+        server_thread = threading.Thread(
+            target=viz.begin_lifecycle,
             kwargs={'server': server, 'interactive': False})
-        self._server_thread.start()
-
-        self.url = 'http://{host}:{port}'.format(host=self.host, port=self.port)
-
-    def __del__(self):
-        self.shutdown()
+        server_thread.start()
+        cls.servers[cfg] = server
+        cls.threads[cfg] = server_thread
+        cls.configs.add(cfg)
+        return server_thread, server
 
     def wait_for_startup(self):
         while self._server_thread.is_alive() and not self._started:
             try:
-                s = socket.create_connection(('localhost', self.port), 0.1)
+                s = socket.create_connection((self.host, self.port), 0.1)
                 self._started = True
             except:
                 pass
             else:
                 s.close()
 
-    def shutdown(self, timeout=None):
-        if self._server_thread.is_alive():
-            # This code might run as part of %reset which might have unloaded
-            # prior imports of urllib2
-            import urllib2
-            urllib2.urlopen(self.url + '/shutdown', timeout=timeout).read()
-        self._server_thread.join()
+    @classmethod
+    def shutdown_all(cls, timeout=None):
+        def get_timeout(start=time.clock()):
+            if timeout is None:
+                return None
+            else:
+                return max(0.001, timeout - (time.clock() - start))
+
+        for cfg in cls.configs:
+            server = cls.servers.get(cfg, None)
+            server_thread = cls.threads.get(cfg, None)
+            if server_thread is not None and server_thread.is_alive():
+                if server is not None:
+                    urllib2.urlopen(
+                        cls.get_url(cls.host, server.server_port, 'shutdown'),
+                        timeout=get_timeout()).read()
+                server_thread.join(get_timeout())
 
     def _ipython_display_(self):
         self.wait_for_startup()
@@ -76,3 +121,6 @@ class IPythonViz(object):
             '''.format(url=self.url, id=uuid.uuid4(), height=self.height)))
         else:
             print "Server is not alive."
+
+
+atexit.register(IPythonViz.shutdown_all, timeout=5)

--- a/nengo_viz/ipython.py
+++ b/nengo_viz/ipython.py
@@ -100,15 +100,6 @@ class IPythonViz(object):
         if self._server_thread.is_alive():
             display(HTML('''
                 <div id="{id}">
-                    <form>
-                        <input
-                            type="button"
-                            onclick="
-                                var target = $('#{id} iframe');
-                                target.attr('src', '{url}' + '/shutdown');
-                                target.load(function () {{ $('#{id}').replaceWith('') }});"
-                            value="Close viz" />
-                    </form>
                     <iframe
                         src="{url}"
                         width="100%"

--- a/nengo_viz/ipython.py
+++ b/nengo_viz/ipython.py
@@ -57,7 +57,7 @@ class IPythonViz(object):
         name = model.label if model.label is not None else ''
         viz = nengo_viz.Viz(
             name, cfg=cfg, model=model, locals=get_ipython().user_ns,
-            interactive=False)
+            interactive=False, allow_file_change=False)
         server = viz.prepare_server(port=0, browser=False)
         server_thread = threading.Thread(
             target=viz.begin_lifecycle,

--- a/nengo_viz/ipython.py
+++ b/nengo_viz/ipython.py
@@ -23,7 +23,8 @@ class IPythonViz(object):
         self.port = server.server_port
 
         self._server_thread = threading.Thread(
-            target=self.viz.begin_lifecycle, kwargs={'server': server})
+            target=self.viz.begin_lifecycle,
+            kwargs={'server': server, 'interactive': False})
         self._server_thread.start()
 
         self.url = 'http://{host}:{port}'.format(host=self.host, port=self.port)

--- a/nengo_viz/ipython.py
+++ b/nengo_viz/ipython.py
@@ -1,0 +1,77 @@
+import nengo_viz
+from IPython.display import display, HTML
+import socket
+import tempfile
+import threading
+import uuid
+
+
+class IPythonViz(object):
+    def __init__(self, model, height=600):
+        nengo_viz.server.Server.log_file = None
+
+        self.height = height
+
+        self._started = False
+
+        self.cfg = tempfile.NamedTemporaryFile()
+        self.viz = nengo_viz.Viz(
+            self.cfg.name, model=model, locals=get_ipython().user_ns)
+        server = self.viz.prepare_server(port=0, browser=False)
+
+        self.host = 'localhost'
+        self.port = server.server_port
+
+        self._server_thread = threading.Thread(
+            target=self.viz.begin_lifecycle, kwargs={'server': server})
+        self._server_thread.start()
+
+        self.url = 'http://{host}:{port}'.format(host=self.host, port=self.port)
+
+    def __del__(self):
+        self.shutdown()
+
+    def wait_for_startup(self):
+        while self._server_thread.is_alive() and not self._started:
+            try:
+                s = socket.create_connection(('localhost', self.port), 0.1)
+                self._started = True
+            except:
+                pass
+            else:
+                s.close()
+
+    def shutdown(self, timeout=None):
+        if self._server_thread.is_alive():
+            # This code might run as part of %reset which might have unloaded
+            # prior imports of urllib2
+            import urllib2
+            urllib2.urlopen(self.url + '/shutdown', timeout=timeout).read()
+        self._server_thread.join()
+
+    def _ipython_display_(self):
+        self.wait_for_startup()
+        if self._server_thread.is_alive():
+            display(HTML('''
+                <div id="{id}">
+                    <form>
+                        <input
+                            type="button"
+                            onclick="
+                                var target = $('#{id} iframe');
+                                target.attr('src', '{url}' + '/shutdown');
+                                target.load(function () {{ $('#{id}').replaceWith('') }});"
+                            value="Close viz" />
+                    </form>
+                    <iframe
+                        src="{url}"
+                        width="100%"
+                        height="{height}"
+                        frameborder="0"
+                        class="cell"
+                        style="border: 1px solid #eee;"
+                        allowfullscreen></iframe>
+                </div>
+            '''.format(url=self.url, id=uuid.uuid4(), height=self.height)))
+        else:
+            print "Server is not alive."

--- a/nengo_viz/server.py
+++ b/nengo_viz/server.py
@@ -150,13 +150,12 @@ class Server(swi.SimpleWebInterface):
             time.sleep(2)
 
             # if there are no simulations left, stop the server
-            if self.server.viz.count_sims() == 0:
-                if isinstance(component, nengo_viz.components.SimControl):
-                    if self.server.viz.interactive:
-                        print(
-                            "No connections remaining to the nengo_viz "
-                            "server.")
-                    self.stop()
+            if isinstance(component, nengo_viz.components.SimControl):
+                if self.server.viz.interactive:
+                    print(
+                        "No connections remaining to the nengo_viz "
+                        "server.")
+                self.server.shutdown()
 
     def log_message(self, format, *args):
         # suppress all the log messages

--- a/nengo_viz/server.py
+++ b/nengo_viz/server.py
@@ -152,7 +152,10 @@ class Server(swi.SimpleWebInterface):
             # if there are no simulations left, stop the server
             if self.server.viz.count_sims() == 0:
                 if isinstance(component, nengo_viz.components.SimControl):
-                    print("No connections remaining to the nengo_viz server.")
+                    if self.server.viz.interactive:
+                        print(
+                            "No connections remaining to the nengo_viz "
+                            "server.")
                     self.stop()
 
     def log_message(self, format, *args):

--- a/nengo_viz/server.py
+++ b/nengo_viz/server.py
@@ -75,10 +75,10 @@ class Server(swi.SimpleWebInterface):
             return self.create_login_form()
 
         # create a new simulator
-        viz_sim = self.viz.create_sim()
+        viz_sim = self.server.viz.create_sim()
 
         #TODO: handle multiple viz_sims at the same time
-        Server.viz_sim = viz_sim
+        self.server.viz_sim = viz_sim
 
         # read the template for the main page
         html = pkgutil.get_data('nengo_viz', 'templates/page.html')
@@ -97,7 +97,7 @@ class Server(swi.SimpleWebInterface):
         """Handles ws://host:port/viz_component with a websocket"""
         # figure out what component is being connected to
 
-        viz_sim = Server.viz_sim
+        viz_sim = self.server.viz_sim
 
         component = viz_sim.uids[uid]
         try:
@@ -114,31 +114,35 @@ class Server(swi.SimpleWebInterface):
                         cfg = json.loads(msg[7:])
                         old_cfg = {}
                         for k in component.template.config_params.keys():
-                            v = getattr(self.viz.config[component.template], k)
+                            v = getattr(
+                                self.server.viz.config[component.template], k)
                             old_cfg[k] = v
                         if not(cfg == old_cfg):
                             # Register config change to the undo stack
-                            self.viz_sim.config_change(component, cfg, old_cfg)
+                            self.server.viz_sim.config_change(
+                                component, cfg, old_cfg)
                         for k, v in cfg.items():
-                            setattr(self.viz.config[component.template], k, v)
-                        self.viz.modified_config()
+                            setattr(
+                                self.server.viz.config[component.template],
+                                k, v)
+                        self.server.viz.modified_config()
                     elif msg.startswith('remove'):
                         if msg != 'remove_undo':
                             # Register graph removal to the undo stack
-                            self.viz_sim.remove_graph(component)
-                        self.viz.remove_uid(uid)
-                        self.viz.modified_config()
+                            self.server.viz_sim.remove_graph(component)
+                        self.server.viz.remove_uid(uid)
+                        self.server.viz.modified_config()
                         return
                     else:
                         component.message(msg)
                     msg = client.read()
                 # send data to the component
                 component.update_client(client)
-                self.viz.save_config(lazy=True)
+                self.server.viz.save_config(lazy=True)
                 time.sleep(0.01)
         except swi.SocketClosedError:
             # This error means the server has shut down, we should stop nicely.
-            self.viz.save_config(lazy=False)
+            self.server.viz.save_config(lazy=False)
         finally:
             component.finish()
 
@@ -146,7 +150,7 @@ class Server(swi.SimpleWebInterface):
             time.sleep(2)
 
             # if there are no simulations left, stop the server
-            if self.viz.count_sims() == 0:
+            if self.server.viz.count_sims() == 0:
                 if isinstance(component, nengo_viz.components.SimControl):
                     print("No connections remaining to the nengo_viz server.")
                     self.stop()

--- a/nengo_viz/static/viz_top_toolbar.css
+++ b/nengo_viz/static/viz_top_toolbar.css
@@ -10,6 +10,15 @@
     background: #666;
 }
 
+#top_toolbar .deactivated .glyphicon {
+    color: #ccc;
+}
+
+#top_toolbar .deactivated .glyphicon:hover {
+    color: #ccc;
+    background: none;
+}
+
 #top_toolbar {
     position: absolute;
     width: 100%;

--- a/nengo_viz/static/viz_top_toolbar.js
+++ b/nengo_viz/static/viz_top_toolbar.js
@@ -20,7 +20,9 @@ VIZ.Toolbar = function(filename) {
     this.toolbar = $('#top_toolbar')[0];
 
     $('#Open_file_button')[0].addEventListener('click', function () {
-        self.file_browser();
+        if (!$(this).hasClass('deactivated')) {
+            self.file_browser();
+        }
     });
     $('#Reset_layout_button')[0].addEventListener('click', function () {
         VIZ.modal.title("Are you sure you wish to reset this layout, " +

--- a/nengo_viz/swi.py
+++ b/nengo_viz/swi.py
@@ -399,7 +399,7 @@ class SimpleWebInterface(BaseHTTPServer.BaseHTTPRequestHandler):
         return server
 
     @classmethod
-    def begin_lifecycle(cls, server, asynch=True):
+    def begin_lifecycle(cls, server, asynch=True, interactive=True):
         try:
             server.running = True
             while server.running:
@@ -407,6 +407,9 @@ class SimpleWebInterface(BaseHTTPServer.BaseHTTPRequestHandler):
                     server.serve_forever(poll_interval=0.02)
                     server.running = False
                 except KeyboardInterrupt:
+                    if not interactive:
+                        raise
+
                     # Check that user wants to shut down
                     sys.stdout.write(
                         "\nShut-down this web server (y/[n])? ")
@@ -421,7 +424,8 @@ class SimpleWebInterface(BaseHTTPServer.BaseHTTPRequestHandler):
                     else:
                         print("No confirmation received. Resuming...")
         finally:
-            print("Shutting down server...")
+            if interactive:
+                print("Shutting down server...")
 
             # shut down any remaining threads
             # server.requests might be modified from other threads, so we need
@@ -440,7 +444,7 @@ class SimpleWebInterface(BaseHTTPServer.BaseHTTPRequestHandler):
 
                 n_zombie = sum(thread.is_alive()
                         for thread, _ in server.requests)
-                if n_zombie > 0:
+                if interactive and n_zombie > 0:
                     print("%d zombie threads will close abruptly" % n_zombie)
 
             cls.servers.remove(server)

--- a/nengo_viz/swi.py
+++ b/nengo_viz/swi.py
@@ -381,16 +381,17 @@ class SimpleWebInterface(BaseHTTPServer.BaseHTTPRequestHandler):
                     format % args))
 
     @classmethod
-    def start(cls, port=80, asynch=True, addr='', browser=False):
-        server = cls.prepare_server(port, asynch, addr, browser)
+    def start(cls, viz, port=80, asynch=True, addr='', browser=False):
+        server = cls.prepare_server(viz, port, asynch, addr, browser)
         cls.begin_lifecycle(server, asynch)
 
     @classmethod
-    def prepare_server(cls, port=80, asynch=True, addr='', browser=False):
+    def prepare_server(cls, viz, port=80, asynch=True, addr='', browser=False):
         if asynch:
             server = AsyncHTTPServer((addr, port), cls)
         else:
             server = BaseHTTPServer.HTTPServer((addr, port), cls)
+        server.viz = viz
         port = server.server_port
         if browser:
             cls.browser(port=port)

--- a/nengo_viz/swi.py
+++ b/nengo_viz/swi.py
@@ -382,15 +382,24 @@ class SimpleWebInterface(BaseHTTPServer.BaseHTTPRequestHandler):
 
     @classmethod
     def start(cls, port=80, asynch=True, addr='', browser=False):
-        if browser:
-            cls.browser(port=port)
+        server = cls.prepare_server(port, asynch, addr, browser)
+        cls.begin_lifecycle(server, asynch)
+
+    @classmethod
+    def prepare_server(cls, port=80, asynch=True, addr='', browser=False):
         if asynch:
             server = AsyncHTTPServer((addr, port), cls)
         else:
             server = BaseHTTPServer.HTTPServer((addr, port), cls)
+        port = server.server_port
+        if browser:
+            cls.browser(port=port)
 
         cls.servers.append(server)
+        return server
 
+    @classmethod
+    def begin_lifecycle(cls, server, asynch=True):
         try:
             server.running = True
             while server.running:

--- a/nengo_viz/swi.py
+++ b/nengo_viz/swi.py
@@ -91,6 +91,8 @@ class SimpleWebInterface(BaseHTTPServer.BaseHTTPRequestHandler):
     current_cookies = {}
     passwords = {}
 
+    log_file = sys.stderr
+
     def add_header(self, key, value):
         if self.pending_headers is None:
             self.pending_headers = []
@@ -371,6 +373,12 @@ class SimpleWebInterface(BaseHTTPServer.BaseHTTPRequestHandler):
                 val = val[:i] + c + val[i + 3:]
             i += 1
         return val
+
+    def log_message(self, format, *args):
+        if self.log_file is not None:
+            self.log_file.write( "%s - - [%s] %s\n" % (
+                    self.client_address[0], self.log_date_time_string(),
+                    format % args))
 
     @classmethod
     def start(cls, port=80, asynch=True, addr='', browser=False):

--- a/nengo_viz/viz.py
+++ b/nengo_viz/viz.py
@@ -100,9 +100,12 @@ class VizSim(object):
 
     def create_javascript(self):
         fn = json.dumps(self.viz.filename[:-3])
-        webpage_title_js = ';document.title = %s' % fn
+        webpage_title_js = ';document.title = %s;' % fn
         component_js = '\n'.join([c.javascript() for c in self.components])
-        component_js = component_js + webpage_title_js
+        component_js += webpage_title_js
+        if not self.viz.allow_file_change:
+            component_js += "$('#Open_file_button').addClass('deactivated');"
+            pass
         return component_js
 
     def config_change(self, component, new_cfg, old_cfg):
@@ -120,9 +123,11 @@ class Viz(object):
     """The master visualization organizer set up for a particular model."""
     def __init__(
             self, filename=None, model=None, locals=None, cfg=None,
-            interactive=True):
+            interactive=True, allow_file_change=True):
         if nengo_viz.monkey.is_executing():
             raise nengo_viz.monkey.StartedVizException()
+
+        self.allow_file_change = allow_file_change
 
         self.viz_sims = []
         self.cfg = cfg

--- a/nengo_viz/viz.py
+++ b/nengo_viz/viz.py
@@ -287,8 +287,9 @@ class Viz(object):
         return nengo_viz.server.Server.prepare_server(
             port=port, browser=browser)
 
-    def begin_lifecycle(self, server):
-        nengo_viz.server.Server.begin_lifecycle(server)
+    def begin_lifecycle(self, server, interactive=True):
+        nengo_viz.server.Server.begin_lifecycle(
+            server, interactive=interactive)
 
     def create_sim(self):
         """Create a new Simulator with this configuration"""

--- a/nengo_viz/viz.py
+++ b/nengo_viz/viz.py
@@ -176,7 +176,7 @@ class Viz(object):
 
 
         self.model = model
-        self.locals = locals
+        self.locals = dict(locals)
 
         self.filename = filename
         self.name_finder = nengo_viz.NameFinder(locals, model)

--- a/nengo_viz/viz.py
+++ b/nengo_viz/viz.py
@@ -143,7 +143,11 @@ class Viz(object):
         self.load(filename, model, locals)
 
     def load(self, filename, model=None, locals=None):
-        filename = os.path.relpath(filename)
+        try:
+            filename = os.path.relpath(filename)
+        except ValueError:
+            pass
+
         if locals is None:
             locals = {}
             locals['nengo_viz'] = nengo_viz

--- a/nengo_viz/viz.py
+++ b/nengo_viz/viz.py
@@ -282,6 +282,14 @@ class Viz(object):
             addr = 'localhost'
         nengo_viz.server.Server.start(port=port, browser=browser, addr=addr)
 
+    def prepare_server(self, port=8080, browser=True):
+        nengo_viz.server.Server.viz = self
+        return nengo_viz.server.Server.prepare_server(
+            port=port, browser=browser)
+
+    def begin_lifecycle(self, server):
+        nengo_viz.server.Server.begin_lifecycle(server)
+
     def create_sim(self):
         """Create a new Simulator with this configuration"""
         viz_sim = VizSim(self)

--- a/nengo_viz/viz.py
+++ b/nengo_viz/viz.py
@@ -288,19 +288,17 @@ class Viz(object):
 
     def start(self, port=8080, browser=True, password=None):
         """Start the web server"""
-        nengo_viz.server.Server.viz = self
         print("Starting nengo_viz server at http://localhost:%d" % port)
         if password is not None:
             nengo_viz.server.Server.add_user('', password)
             addr = ''
         else:
             addr = 'localhost'
-        nengo_viz.server.Server.start(port=port, browser=browser, addr=addr)
+        nengo_viz.server.Server.start(self, port=port, browser=browser, addr=addr)
 
-    def prepare_server(self, port=8080, browser=True):
-        nengo_viz.server.Server.viz = self
+    def prepare_server(self, viz, port=8080, browser=True):
         return nengo_viz.server.Server.prepare_server(
-            port=port, browser=browser)
+            self, port=port, browser=browser)
 
     def begin_lifecycle(self, server):
         nengo_viz.server.Server.begin_lifecycle(

--- a/nengo_viz/viz.py
+++ b/nengo_viz/viz.py
@@ -223,6 +223,7 @@ class Viz(object):
 
     def load_config(self):
         config = nengo_viz.config.Config()
+        self.locals['nengo_viz'] = nengo_viz
         self.locals['_viz_config'] = config
         fname = self.config_name()
         if os.path.exists(fname):

--- a/nengo_viz/viz.py
+++ b/nengo_viz/viz.py
@@ -164,6 +164,7 @@ class Viz(object):
                         line = nengo_viz.monkey.determine_line_number()
                         print('nengo_viz.Viz() started on line %d. '
                               'Ignoring all subsequent lines.' % line)
+        self.orig_locals = dict(locals)
 
         if model is None:
             if 'model' not in locals:

--- a/nengo_viz/viz.py
+++ b/nengo_viz/viz.py
@@ -118,11 +118,12 @@ class VizSim(object):
 
 class Viz(object):
     """The master visualization organizer set up for a particular model."""
-    def __init__(self, filename, model=None, locals=None):
+    def __init__(self, filename=None, model=None, locals=None, cfg=None):
         if nengo_viz.monkey.is_executing():
             raise nengo_viz.monkey.StartedVizException()
 
         self.viz_sims = []
+        self.cfg = cfg
 
         self.config_save_period = 2.0  # minimum time between saves
 
@@ -200,7 +201,10 @@ class Viz(object):
         del self.default_labels[obj]
 
     def config_name(self):
-        return self.filename + '.cfg'
+        if self.cfg is None:
+            return self.filename + '.cfg'
+        else:
+            return self.cfg
 
     def load_config(self):
         config = nengo_viz.config.Config()


### PR DESCRIPTION
Opening this PR for people to take a look at and try out. It seems to be working quite well already, but there are a few more things which should maybe addressed.

This allows to embed the nengo_viz visualization easily in IPython notebooks. Just do
```python
from nengo_viz.ipython import IPythonViz
IPythonViz(model)
```

Assigning the `IPythonViz` object to a variable and displaying it multiple times should work (it's like opening multiple tabs for nengo_viz). Different `IPythonViz` objects should be able to coexist.

Potential things to do:
* [x] On shutdown the server produces output which will be displayed the next time a cell is executed after server shutdown. Probably that output should be suppressed.
* [x] There always seems to be Zombie threads remaining after shutdown. Maybe the timeout is just too short? :point_right: Solved in PR #227.
* [ ] Do we want to automatically display model with nengo_viz in IPy Notebooks? (without having it to enclose in `IPythonViz(...)`? :point_right: We probably don't have to decide this now and can leave it for a potential later PR.
* [x] The config should probably live longer than just one IPythonViz lifecycle ... but I'm not sure whether one config per IPython kernel is the correct approach. There might be different models defined in one kernel? :point_right: It is now possible to pass a filename to persist the config. I don't think there is a way to figure out which config to use without this additional information because we don't know whether two models are supposed to be the same.
* [x] The file open toolbar button should probably removed for the embedded visualization. (It should work fine, but might be confusing.)
* [x] The filename in the toolbar isn't helpful either, and actually non-existent.
* [x] something related to the server side, but I forgot :point_right: I believe it was about what I commented on in f97b743a10f057290741aca1befa9d6d47a8826d. If not, it probably wasn't that important.