### PR TITLE
Handle loading bad files

### DIFF
--- a/nengo_viz/components/sim_control.py
+++ b/nengo_viz/components/sim_control.py
@@ -1,5 +1,6 @@
 import time
 import struct
+import traceback
 
 import numpy as np
 import nengo
@@ -115,11 +116,11 @@ class SimControl(Component):
                 self.viz.rebuild = True
             self.paused = False
         elif msg[:4] == 'open':
-            if os.path.isfile(self.viz.viz.filename):
+            try:
                 self.viz.viz.load(msg[4:])
                 self.reload = True
-            else:
-                print('File does not exist')
+            except:
+                traceback.print_exc()
         elif msg == 'reset':
             if os.path.isfile(self.viz.viz.filename + '.cfg') :
                 os.remove(self.viz.viz.filename + '.cfg')

--- a/nengo_viz/monkey.py
+++ b/nengo_viz/monkey.py
@@ -1,17 +1,21 @@
+import contextlib
 import importlib
 import threading
-import sys
 import traceback
-import contextlib
+import sys
+
 
 # list of Simulators to check for
-known_modules = ['nengo', 'nengo_ocl']
+known_modules = ['nengo', 'nengo_ocl', 'nengo_brainstorm', 'nengo_distilled']
+
 
 class StartedSimulatorException(Exception):
     pass
 
+
 class StartedVizException(Exception):
     pass
+
 
 # create a wrapper class that will throw an exception if we are
 # currently executing a script
@@ -23,11 +27,14 @@ def make_dummy(cls):
             super(DummySimulator, self).__init__(*args, **kwargs)
     return DummySimulator
 
+
 # thread local storage for storing whether we are executing a script
 flag = threading.local()
 
+
 def is_executing():
     return getattr(flag, 'executing', False)
+
 
 def determine_line_number(filename='<string>'):
     '''Checks stack trace to determine the line number we are currently at.
@@ -41,6 +48,7 @@ def determine_line_number(filename='<string>'):
         if fn == filename:
             return line
     return None
+
 
 @contextlib.contextmanager
 def patch():
@@ -57,7 +65,3 @@ def patch():
     for mod, cls in simulators.items():
         mod.Simulator = cls
     flag.executing = False
-
-
-
-

--- a/nengo_viz/monkey.py
+++ b/nengo_viz/monkey.py
@@ -1,0 +1,34 @@
+import importlib
+import threading
+
+# list of Simulators to check for
+known_modules = ['nengo', 'nengo_ocl']
+
+class StartedSimulatorException(Exception):
+    pass
+
+class StartedVizException(Exception):
+    pass
+
+# create a wrapper class that will throw an exception if we are
+# currently executing a script
+def make_dummy(cls):
+    class DummySimulator(cls):
+        def __init__(self, *args, **kwargs):
+            if is_executing():
+                raise StartedSimulatorException()
+            super(DummySimulator, self).__init__(*args, **kwargs)
+    return DummySimulator
+
+for name in known_modules:
+    try:
+        mod = importlib.import_module(name)
+        mod.Simulator = make_dummy(mod.Simulator)
+    except ImportError:
+        pass
+
+# thread local storage for storing whether we are executing a script
+flag = threading.local()
+
+def is_executing():
+    return getattr(flag, 'executing', False)

--- a/nengo_viz/monkey.py
+++ b/nengo_viz/monkey.py
@@ -1,5 +1,7 @@
 import importlib
 import threading
+import sys
+import traceback
 
 # list of Simulators to check for
 known_modules = ['nengo', 'nengo_ocl']
@@ -32,3 +34,16 @@ flag = threading.local()
 
 def is_executing():
     return getattr(flag, 'executing', False)
+
+def determine_line_number(filename='<string>'):
+    '''Checks stack trace to determine the line number we are currently at.
+
+    The default filname argument of "<string>" indicates it should only
+    pay attention to the line numbers in the main evaluated script (which
+    is evaluated using exec(), so it doesn't have a normal filename).
+    '''
+    tb = traceback.extract_tb(sys.exc_traceback)
+    for fn, line, function, code in reversed(tb):
+        if fn == filename:
+            return line
+    return None

--- a/nengo_viz/viz.py
+++ b/nengo_viz/viz.py
@@ -141,7 +141,7 @@ class Viz(object):
                           'Ignoring all subsequent lines.' % line)
                 except nengo_viz.monkey.StartedVizException:
                     line = nengo_viz.monkey.determine_line_number()
-                    print('nengo.Viz() started on line %d. '
+                    print('nengo_viz.Viz() started on line %d. '
                           'Ignoring all subsequent lines.' % line)
 
         if model is None:

--- a/nengo_viz/viz.py
+++ b/nengo_viz/viz.py
@@ -132,19 +132,17 @@ class Viz(object):
 
             with open(filename) as f:
                 code = f.read()
-            nengo_viz.monkey.flag.executing = True
-            try:
-                exec(code, locals)
-            except nengo_viz.monkey.StartedSimulatorException:
-                line = nengo_viz.monkey.determine_line_number()
-                print('nengo.Simulator() started on line %d. '
-                      'Ignoring all subsequent lines.' % line)
-            except nengo_viz.monkey.StartedVizException:
-                line = nengo_viz.monkey.determine_line_number()
-                print('nengo.Viz() started on line %d. '
-                      'Ignoring all subsequent lines.' % line)
-            finally:
-                nengo_viz.monkey.flag.executing = False
+            with nengo_viz.monkey.patch():
+                try:
+                    exec(code, locals)
+                except nengo_viz.monkey.StartedSimulatorException:
+                    line = nengo_viz.monkey.determine_line_number()
+                    print('nengo.Simulator() started on line %d. '
+                          'Ignoring all subsequent lines.' % line)
+                except nengo_viz.monkey.StartedVizException:
+                    line = nengo_viz.monkey.determine_line_number()
+                    print('nengo.Viz() started on line %d. '
+                          'Ignoring all subsequent lines.' % line)
 
         if model is None:
             if 'model' not in locals:

--- a/nengo_viz/viz.py
+++ b/nengo_viz/viz.py
@@ -120,36 +120,37 @@ class Viz(object):
         self.load(filename, model, locals)
 
     def load(self, filename, model=None, locals=None):
-        try:
-            if locals is None:
-                locals = {}
-                with open(filename) as f:
-                    code = f.read()
-                exec(code, locals)
+        if locals is None:
+            locals = {}
+            with open(filename) as f:
+                code = f.read()
+            exec(code, locals)
 
-            if model is None:
-                model = locals['model']
+        if model is None:
+            if 'model' not in locals:
+                raise VizException('No object called "model" in the code')
+            model = locals['model']
+            if not isinstance(model, nengo.Network):
+                raise VizException('The "model" must be a nengo.Network')
 
 
-            locals['nengo_viz'] = nengo_viz
+        locals['nengo_viz'] = nengo_viz
 
-            self.model = model
-            self.locals = locals
+        self.model = model
+        self.locals = locals
 
-            self.filename = filename
-            self.name_finder = nengo_viz.NameFinder(locals, model)
-            self.default_labels = self.name_finder.known_name
+        self.filename = filename
+        self.name_finder = nengo_viz.NameFinder(locals, model)
+        self.default_labels = self.name_finder.known_name
 
-            self.config = self.load_config()
-            self.config_save_needed = False
-            self.config_save_needed = False
-            self.config_save_time = None   # time of last config file save
+        self.config = self.load_config()
+        self.config_save_needed = False
+        self.config_save_needed = False
+        self.config_save_time = None   # time of last config file save
 
-            self.lock = threading.Lock()
+        self.lock = threading.Lock()
 
-            self.uid_prefix_counter = {}
-        except:
-            return 'failure'
+        self.uid_prefix_counter = {}
 
     def find_templates(self):
         for k, v in self.locals.items():

--- a/nengo_viz/viz.py
+++ b/nengo_viz/viz.py
@@ -136,9 +136,13 @@ class Viz(object):
             try:
                 exec(code, locals)
             except nengo_viz.monkey.StartedSimulatorException:
-                pass
+                line = nengo_viz.monkey.determine_line_number()
+                print('nengo.Simulator() started on line %d. '
+                      'Ignoring all subsequent lines.' % line)
             except nengo_viz.monkey.StartedVizException:
-                pass
+                line = nengo_viz.monkey.determine_line_number()
+                print('nengo.Viz() started on line %d. '
+                      'Ignoring all subsequent lines.' % line)
             finally:
                 nengo_viz.monkey.flag.executing = False
 


### PR DESCRIPTION
This now handles some of the cases of weirdnesses that can happen when loading

- Any exception is printed to the console and we recover gracefully.  In a future PR this exception should be sent to the browser and displayed somehow
- If the script creates a Simulator object (either nengo.Simulator or nengo_ocl.Simulator), it stops executing the script at that point (before build)
- If the script creates a Viz object, it stops executing at that point

This means we no longer need ```if __name__ == '__main__':``` protection in the example scripts (issue #101).