### PR TITLE
Make Modal a class instead of singleton

### DIFF
--- a/nengo_viz/disposable_js.py
+++ b/nengo_viz/disposable_js.py
@@ -20,18 +20,18 @@ def infomodal(ng, uid, **args):
         raise NotImplementedError()
 
 def add_modal_title_js(title_text):
-    return 'VIZ.Modal.title("%s");' % (title_text)
+    return 'VIZ.modal.title("%s");' % (title_text)
 
 def add_modal_footer_js(footer_text):
-    return 'VIZ.Modal.footer("%s");' % (footer_text)
+    return 'VIZ.modal.footer("%s");' % (footer_text)
 
 def show_modal_js():
-    return 'VIZ.Modal.show();'
+    return 'VIZ.modal.show();'
 
-def configmodal(): 
+def configmodal():
     js = [add_modal_title_js('Config menu')]
     js.append(add_modal_footer_js('close'))
-    js.append('VIZ.Modal.info_body([]);')
+    js.append('VIZ.modal.clear_body();')
     js.append(show_modal_js())
     return '\n'.join(js)
 
@@ -93,11 +93,11 @@ def ensemble_infomodal(ng, uid, conn_in_uids, conn_out_uids):
 
     conninfo = conn_infomodal(ng, uid, conn_in_uids, conn_out_uids)
 
-    js = ['VIZ.Modal.title("Details for \'%s\'");' % ng.viz.viz.get_label(ens)]
-    js.append('VIZ.Modal.footer("close");')
-    js.append('VIZ.Modal.ensemble_body("%s", %s, %s, %s);' % (
+    js = ['VIZ.modal.title("Details for \'%s\'");' % ng.viz.viz.get_label(ens)]
+    js.append('VIZ.modal.footer("close");')
+    js.append('VIZ.modal.ensemble_body("%s", %s, %s, %s);' % (
         uid, json.dumps(params), json.dumps(plots), json.dumps(conninfo)))
-    js.append('VIZ.Modal.show();')
+    js.append('VIZ.modal.show();')
     return '\n'.join(js)
 
 def node_infomodal(ng, uid, conn_in_uids, conn_out_uids):
@@ -130,7 +130,7 @@ def node_infomodal(ng, uid, conn_in_uids, conn_out_uids):
     js = [add_modal_title_js("Details for \'%s\'" % (
         ng.viz.viz.get_label(node)))]
     js.append(add_modal_footer_js('close'))
-    js.append('VIZ.Modal.node_body("%s", %s, %s, %s);' % (
+    js.append('VIZ.modal.node_body("%s", %s, %s, %s);' % (
         uid, json.dumps(params), json.dumps(plots), json.dumps(conninfo)))
     js.append(show_modal_js())
     return '\n'.join(js)
@@ -205,7 +205,7 @@ def net_infomodal(ng, uid, conn_in_uids, conn_out_uids):
     js = [add_modal_title_js("Details for \'%s\'") % (
         ng.viz.viz.get_label(net))]
     js.append(add_modal_footer_js('close'))
-    js.append('VIZ.Modal.net_body("%s", %s, %s);' % (
+    js.append('VIZ.modal.net_body("%s", %s, %s);' % (
         uid, json.dumps(stats), json.dumps(conninfo)))
     js.append(show_modal_js())
     return '\n'.join(js)

--- a/nengo_viz/static/viz_top_toolbar.js
+++ b/nengo_viz/static/viz_top_toolbar.js
@@ -1,6 +1,6 @@
 /**
  * Toolbar for the top of the GUI
- * @constructor 
+ * @constructor
  *
  * @param {string} filename - The name of the file opened
  */
@@ -19,19 +19,23 @@ VIZ.Toolbar = function(filename) {
     /** keep a reference to the toolbar element */
     this.toolbar = $('#top_toolbar')[0];
 
-    $('#Open_file_button')[0].addEventListener('click', function () {self.file_browser()});
+    $('#Open_file_button')[0].addEventListener('click', function () {
+        self.file_browser();
+    });
     $('#Reset_layout_button')[0].addEventListener('click', function () {
-        VIZ.Modal.title("Are you sure you wish to reset this layout, removing all the graphs and resetting the position of all items?");
-        VIZ.Modal.info_body([]);
-        VIZ.Modal.footer('confirm_reset');
-        VIZ.Modal.show();
-        });
+        VIZ.modal.title("Are you sure you wish to reset this layout, " +
+                        "removing all the graphs and resetting the position " +
+                        "of all items?");
+        VIZ.modal.text_body("This operation cannot be undone!", "danger");
+        VIZ.modal.footer('confirm_reset');
+        VIZ.modal.show();
+    });
 
     // TODO: hookup undo and redo
     // $('#Undo_last_button')[0].addEventListener('click', function () {});
     // $('#Redo_last_button')[0].addEventListener('click', function () {});
     $('#Config_button')[0].addEventListener('click', function () {self.start_modal()});
-   
+
     $('#filename')[0].innerHTML = filename;
 
     this.menu = new VIZ.Menu(this.toolbar);
@@ -51,18 +55,18 @@ VIZ.Toolbar.prototype.file_browser = function () {
         fb.fileTree({
             root: '.',
             script: '/browse'
-        }, 
+        },
         function (file) {
             var msg = 'open' + file
             sim.ws.send(msg);})
     }
 };
 
-/** This is run once a file is selected, trims the filename 
+/** This is run once a file is selected, trims the filename
  *  and sends it to the server. */
 VIZ.Toolbar.prototype.file_name = function() {
     var filename = document.getElementById('open_file').value;
-    filename = filename.replace("C:\\fakepath\\", ""); 
+    filename = filename.replace("C:\\fakepath\\", "");
     sim.ws.send('open' + filename);
 };
 
@@ -73,7 +77,7 @@ VIZ.Toolbar.prototype.reset_model_layout = function () {
 }
 
 /** Function called by event handler in order to launch modal.
- *  First check to make sure modal isn't open already, then send 
+ *  First check to make sure modal isn't open already, then send
  *  call to server to generate modal javascript from config. */
 VIZ.Toolbar.prototype.start_modal = function () {
     sim.ws.send('config')


### PR DESCRIPTION
While we won't do this, it makes it possible to make multiple modals. The major advantage here is just that the Javascript code looks more idiomatic.

The main reason I did this was because info_body was being used to clear the body, which is overkill (and adds divs we don't want). So I also added a clear_body function. And a text_body function, which the reset modal now uses (it is resettable right?)

I know that this'll make merging #186 and #195 a bit more complicated, but the history of those branches needs to be fixed up anyhow (which I'm happy to do!)