### PR TITLE
Timely thread shutdown

### DIFF
--- a/nengo_viz/swi.py
+++ b/nengo_viz/swi.py
@@ -406,8 +406,10 @@ class SimpleWebInterface(BaseHTTPServer.BaseHTTPRequestHandler):
             print("Shutting down server...")
 
             # shut down any remaining threads
+            # server.requests might be modified from other threads, so we need
+            # a copy which we get in a thread-safe way be slicing it with [:].
             if asynch and server.requests is not None:
-                for _, sock in server.requests:
+                for _, sock in server.requests[:]:
                     try:
                         sock.shutdown(socket.SHUT_RDWR)
                         sock.close()
@@ -415,7 +417,7 @@ class SimpleWebInterface(BaseHTTPServer.BaseHTTPRequestHandler):
                         pass
 
                 first = True
-                for thread, _ in server.requests:
+                for thread, _ in server.requests[:]:
                     if thread.is_alive():
                         # giving the first thread more time to close
                         # effectively gives all threads more time to close
@@ -423,7 +425,7 @@ class SimpleWebInterface(BaseHTTPServer.BaseHTTPRequestHandler):
                         first = False
 
                 n_zombie = sum(thread.is_alive()
-                               for thread, _ in server.requests)
+                        for thread, _ in server.requests[:])
                 if n_zombie > 0:
                     print("%d zombie threads will close abruptly" % n_zombie)
 
@@ -447,22 +449,14 @@ class AsyncHTTPServer(SocketServer.ThreadingMixIn, BaseHTTPServer.HTTPServer):
         BaseHTTPServer.HTTPServer.__init__(self, *args, **kwargs)
 
         # keep track of open threads, so we can close them when we exit
-        self._requests = []
-        self._requests_lock = threading.Lock()
-
-    @property
-    def requests(self):
-        with self._requests_lock:
-            return list(self._requests)
+        self.requests = []
 
     def process_request_thread(self, request, client_address):
         thread = threading.current_thread()
-        with self._requests_lock:
-            self._requests.append((thread, request))
+        self.requests.append((thread, request))
         SocketServer.ThreadingMixIn.process_request_thread(
             self, request, client_address)
-        with self._requests_lock:
-            self._requests.remove((thread, request))
+        self.requests.remove((thread, request))
 
     def handle_error(self, request, client_address):
         exc_type, exc_value, _ = sys.exc_info()

--- a/nengo_viz/swi.py
+++ b/nengo_viz/swi.py
@@ -419,7 +419,7 @@ class SimpleWebInterface(BaseHTTPServer.BaseHTTPRequestHandler):
                     if thread.is_alive():
                         # giving the first thread more time to close
                         # effectively gives all threads more time to close
-                        thread.join(0.05 if first else 0.01)
+                        thread.join(0.2 if first else 0.01)
                         first = False
 
                 n_zombie = sum(thread.is_alive()

--- a/nengo_viz/swi.py
+++ b/nengo_viz/swi.py
@@ -402,7 +402,11 @@ class SimpleWebInterface(BaseHTTPServer.BaseHTTPRequestHandler):
             # shut down any remaining threads
             if asynch and server.requests is not None:
                 for _, sock in server.requests:
-                    sock.close()
+                    try:
+                        sock.shutdown(socket.SHUT_RDWR)
+                        sock.close()
+                    except socket.error:
+                        pass
 
                 first = True
                 for thread, _ in server.requests:

--- a/nengo_viz/swi.py
+++ b/nengo_viz/swi.py
@@ -36,41 +36,41 @@ Websockets are also supported via functions that begin with ws_:
                 client.write('received: ' + msg)
 """
 
+import base64
 try:
     import BaseHTTPServer
 except ImportError:
     import http.server as BaseHTTPServer
-try:
-    import SocketServer
-except ImportError:
-    import socketserver as SocketServer
-import traceback
-import random
-import select
-import string
-import sys
 import errno
-import os
-try:
-    import StringIO
-except ImportError:
-    import io as StringIO
+import hashlib
 try:
     import mimetools
 except ImportError:
     import email as mimetools
+import mimetypes
 try:
     import multifile
 except ImportError:
     import email as multifile
+import os
+import random
 import re
-import webbrowser
-import mimetypes
-import base64
-import hashlib
+import select
 import socket
+try:
+    import SocketServer
+except ImportError:
+    import socketserver as SocketServer
+import string
 import struct
+try:
+    import StringIO
+except ImportError:
+    import io as StringIO
+import sys
 import threading
+import traceback
+import webbrowser
 
 
 class SocketClosedError(IOError):


### PR DESCRIPTION
This solves problems resulting in the frequent 'x zombie threads killed' message on shutdown (cp. PR #221). See commits (and commit messages) for details. Essentially, `close()` on a socket might take until the object is garbage collected. For an instant close `shutdown` has to be called beforehand, but that can lead to exceptions because threads are suddenly missing their sockets, so that has to be taken care of. And lastly, their where iterations over a list while it was modified. That's never a good idea.

Time to sleep now ... :sleeping: 