### PR TITLE
Closed the websocket of a component after it is removed. 

### DIFF
--- a/nengo_viz/server.py
+++ b/nengo_viz/server.py
@@ -99,6 +99,7 @@ class Server(swi.SimpleWebInterface):
                             self.viz_sim.remove_graph(component)
                         self.viz.remove_uid(uid)
                         self.viz.modified_config()
+                        return
                     else:
                         component.message(msg)
                     msg = client.read()


### PR DESCRIPTION
This caused a bug where multiple threads trying to update the client caused a crash for the semantic pointer plot.