### PR TITLE
Fixed filename display on Windows

### DIFF
--- a/nengo_viz/components/sim_control.py
+++ b/nengo_viz/components/sim_control.py
@@ -102,7 +102,7 @@ class SimControl(Component):
         info = dict(uid=self.uid)
         fn = json.dumps(self.viz.viz.filename)
         js = self.javascript_config(info)
-        return ('sim = new VIZ.SimControl(control, %s);\n' \
+        return ('sim = new VIZ.SimControl(control, %s);\n'
                 'toolbar = new VIZ.Toolbar(%s); ' % (js, fn))
 
     def message(self, msg):

--- a/nengo_viz/components/sim_control.py
+++ b/nengo_viz/components/sim_control.py
@@ -100,11 +100,9 @@ class SimControl(Component):
 
     def javascript(self):
         info = dict(uid=self.uid)
-        json = self.javascript_config(info)
-        fn = repr(self.viz.viz.filename)
-        if fn.startswith('u'):
-            fn = fn[1:]
-        return 'sim = new VIZ.SimControl(control, %s); ' % json + \
+        fn = json.dumps(self.viz.viz.filename)
+        js = self.javascript_config(info)
+        return 'sim = new VIZ.SimControl(control, %s); ' % js + \
                'toolbar = new VIZ.Toolbar(%s); ' % fn
 
     def message(self, msg):

--- a/nengo_viz/components/sim_control.py
+++ b/nengo_viz/components/sim_control.py
@@ -102,8 +102,8 @@ class SimControl(Component):
         info = dict(uid=self.uid)
         fn = json.dumps(self.viz.viz.filename)
         js = self.javascript_config(info)
-        return 'sim = new VIZ.SimControl(control, %s); ' % js + \
-               'toolbar = new VIZ.Toolbar(%s); ' % fn
+        return ('sim = new VIZ.SimControl(control, %s);\n' \
+                'toolbar = new VIZ.Toolbar(%s); ' % (js, fn))
 
     def message(self, msg):
         if msg == 'pause':

--- a/nengo_viz/components/sim_control.py
+++ b/nengo_viz/components/sim_control.py
@@ -101,8 +101,11 @@ class SimControl(Component):
     def javascript(self):
         info = dict(uid=self.uid)
         json = self.javascript_config(info)
+        fn = repr(self.viz.viz.filename)
+        if fn.startswith('u'):
+            fn = fn[1:]
         return 'sim = new VIZ.SimControl(control, %s); ' % json + \
-               'toolbar = new VIZ.Toolbar("%s"); ' % self.viz.viz.filename 
+               'toolbar = new VIZ.Toolbar(%s); ' % fn
 
     def message(self, msg):
         if msg == 'pause':

--- a/nengo_viz/viz.py
+++ b/nengo_viz/viz.py
@@ -1,6 +1,7 @@
 import os
 import time
 import threading
+import json
 
 import nengo
 
@@ -92,7 +93,8 @@ class VizSim(object):
         self.viz.remove_sim(self)
 
     def create_javascript(self):
-        webpage_title_js = ';document.title = "%s"' %self.viz.filename[:-3]
+        fn = json.dumps(self.viz.filename[:-3])
+        webpage_title_js = ';document.title = %s' % fn
         component_js = '\n'.join([c.javascript() for c in self.components])
         component_js = component_js + webpage_title_js
         return component_js


### PR DESCRIPTION
On Windows, the paths include backslashes, which
weren't being escaped in the string, so they were bring
interpretted as special escape characters