### PR TITLE
Removed extraneous path from default labels

### DIFF
--- a/nengo_viz/viz.py
+++ b/nengo_viz/viz.py
@@ -363,6 +363,8 @@ class Viz(object):
         label = obj.label
         if label is None:
             label = default_labels.get(obj, None)
+            if '.' in label:
+                label = label.rsplit('.', 1)[1]
         if label is None:
             label = repr(obj)
         return label


### PR DESCRIPTION
If nengo_viz is inventing a label, it used to do something
like "model.net.subnet.input". All of the stuff before the
last "." is redundant, since that's already shown by
nesting inside the visual display.  So this change cuts it
down to just "input".