### PR TITLE
Perform a proper closing handshake for websockets.

### DIFF
--- a/nengo_viz/swi.py
+++ b/nengo_viz/swi.py
@@ -543,6 +543,9 @@ class ClientSocket(object):
         datalen = data[1] & 0x7F
 
         if opcode == 8:
+            code = 0b10001000
+            ack = struct.pack('!BB', code, 0)
+            self.socket.send(ack)
             raise SocketClosedError("Websocket has been closed")
 
         offset = 0


### PR DESCRIPTION
Addresses #222 and hopefully fixes it.

Without properly closing the connection it seems that Firefox treats it as an unexpected close due to an error which increases a delay before new websocket connections are allowed.