### PR TITLE
Move items to front on drag

### DIFF
--- a/nengo_viz/static/viz_netgraph_item.js
+++ b/nengo_viz/static/viz_netgraph_item.js
@@ -98,6 +98,9 @@ VIZ.NetGraphItem = function(ng, info) {
         .draggable({
             onstart: function () {
                 self.menu.hide_any();
+                if (!self.expanded) {
+                    self.g.parentNode.appendChild(self.g); // move to front
+                }
             },
             onmove: function(event) {
                 var w = ng.get_scaled_width();

--- a/nengo_viz/static/viz_netgraph_item.js
+++ b/nengo_viz/static/viz_netgraph_item.js
@@ -98,9 +98,7 @@ VIZ.NetGraphItem = function(ng, info) {
         .draggable({
             onstart: function () {
                 self.menu.hide_any();
-                if (!self.expanded) {
-                    self.g.parentNode.appendChild(self.g); // move to front
-                }
+                self.move_to_front();
             },
             onmove: function(event) {
                 var w = ng.get_scaled_width();
@@ -262,6 +260,14 @@ VIZ.NetGraphItem = function(ng, info) {
 VIZ.NetGraphItem.prototype.set_label = function(label) {
     this.label.innerHTML = label;
 }
+
+VIZ.NetGraphItem.prototype.move_to_front = function() {
+    this.g.parentNode.appendChild(this.g);
+
+    for (var item in this.children) {
+        this.children[item].move_to_front();
+    }
+};
 
 VIZ.NetGraphItem.prototype.generate_menu = function () {
     var self = this;


### PR DESCRIPTION
This is meant to address #244 and #141 .  It moves NetGraphItems to the front whenever they are dragged.

However, it's not yet a perfect solution.  It currently does not move expanded Networks to the front, since that would put them on top of any child networks that are currently expanded.  I need to add some logic for that.