### PR TITLE
Use delta value in zooming.

### DIFF
--- a/nengo_viz/static/viz_netgraph.js
+++ b/nengo_viz/static/viz_netgraph.js
@@ -116,7 +116,7 @@ VIZ.NetGraph = function(parent, args) {
             switch (event.deltaMode) {
                 case 1:  // DOM_DELTA_LINE
                     if (event.deltaY != 0) {
-                        var delta = Math.log(1. + Math.abs(event.deltaY)) * 30;
+                        var delta = Math.log(1. + Math.abs(event.deltaY)) * 60;
                         if (event.deltaY < 0) {
                             delta *= -1;
                         }
@@ -134,7 +134,7 @@ VIZ.NetGraph = function(parent, args) {
                     break;
             }
 
-            var scale = 1. + Math.abs(delta) / 400.;
+            var scale = 1. + Math.abs(delta) / 600.;
             if (delta < 0) {
                 scale = 1. / scale;
             }

--- a/nengo_viz/static/viz_netgraph.js
+++ b/nengo_viz/static/viz_netgraph.js
@@ -107,19 +107,37 @@ VIZ.NetGraph = function(parent, args) {
     interact(document.getElementById('main'))
         .on('wheel', function(event) {
             event.preventDefault();
-            if (self.in_zoom_delay) {
-                return;
-            }
-            self.in_zoom_delay = true;
-            setTimeout(function () { self.in_zoom_delay = false; }, 50);
 
             self.menu.hide_any();
 
             var x = (event.clientX / $(self.svg).width())
             var y = (event.clientY / $(self.svg).height());
 
-            var delta = event.wheelDeltaY || -event.deltaY
-            var scale = delta > 0 ? viewport.scale_step_size : 1.0 / viewport.scale_step_size; // will either be 1.1 or ~0.9
+            switch (event.deltaMode) {
+                case 1:  // DOM_DELTA_LINE
+                    if (event.deltaY != 0) {
+                        var delta = Math.log(1. + Math.abs(event.deltaY)) * 30;
+                        if (event.deltaY < 0) {
+                            delta *= -1;
+                        }
+                    } else {
+                        var delta = 0;
+                    }
+                    break;
+                case 2:  // DOM_DELTA_PAGE
+                    // No idea what device would generate scrolling by a page
+                    var delta = 0;
+                    break;
+                case 0:  // DOM_DELTA_PIXEL
+                default:  // Assume pixel if unknown
+                    var delta = event.deltaY;
+                    break;
+            }
+
+            var scale = 1. + Math.abs(delta) / 400.;
+            if (delta < 0) {
+                scale = 1. / scale;
+            }
 
             VIZ.Component.save_components();
 

--- a/nengo_viz/static/viz_viewport.js
+++ b/nengo_viz/static/viz_viewport.js
@@ -2,9 +2,7 @@ VIZ.Viewport = function() {
     this.x = 0;
     this.y = 0;
     this.scale = 1.0;
-    
-    this.scale_step_size = 1.1;
-    
+
     this.w = $("#main").width();
     this.h = $("#main").height();
     var self = this;


### PR DESCRIPTION
Unsatisfied with all attempts to fix the zooming, I did some research on my own. The first things on SO you find on this are actually outdated or the people don't know what they are talking about. The wheel event delta values are actually not as widely inconsistent as it may appear in the first place. Though there are some inconsistencies across browserse, platforms, and devices, they are in a sensible range and we don't have to achieve exactly the same result for any combination as long as it feels ok for any combination.

I tested this PR with
* Chrome, Firefox, and Safari on OS X
* Chrome, Firefox in a Windows VM

Trackpad zooming on OS X feels super smooth. :sparkles: Mouse wheel works well (a bit better in Firefox I think). On Windows it didn't feel as nice, but still ok/usable. The main issue there is probably that I don't have proper mouse drivers installed and one scroll wheel click is counted as scrolling by 3 lines (even scrolling a normal text page in the browser doesn't feel any better). Trackpad feels the same because it is treated as a normal mouse wheel in the VM.

So test this and see whether it works on your systems and devices! There is still range for sensitivity adjustments.

This would make PR #240 obsolete.