### PR TITLE
Handle any sort of error on backend import during monkeypatch

### DIFF
--- a/nengo_viz/monkey.py
+++ b/nengo_viz/monkey.py
@@ -57,10 +57,10 @@ def patch():
     for name in known_modules:
         try:
             mod = importlib.import_module(name)
-            simulators[mod] = mod.Simulator
-            mod.Simulator = make_dummy(mod.Simulator)
-        except ImportError:
-            pass
+        except:
+            continue
+        simulators[mod] = mod.Simulator
+        mod.Simulator = make_dummy(mod.Simulator)
     yield
     for mod, cls in simulators.items():
         mod.Simulator = cls


### PR DESCRIPTION
When it tries to import nengo modules for the monkey-patching,
it might get something other than an ImportError if that module
is installed wrong.  For example, nengo_ocl on my machine
currently raises an AttributeError.  This change causes it to
handle any error raised.