### PR TITLE
Add Vargant stuff to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ target/
 
 # nengo_viz specific
 *.py.cfg
+
+# Vagrant
+.vagrant
+Vagrantfile


### PR DESCRIPTION
Did some Windows testing with vagrant and don't want to have these files always show up in the status report.