### PR TITLE
Restyle toolbar shadows.

### DIFF
--- a/nengo_viz/static/viz_sim_control.css
+++ b/nengo_viz/static/viz_sim_control.css
@@ -2,7 +2,7 @@
 /* or do we want to dynamically raise it when other elements have theirs increased  */
 .sim_control {
     background-color: #eee;
-    box-shadow: 0 0 12px 1px rgba(87,87,87,0.2);
+    box-shadow: 0px -2px 4px 0px #999;
     height: 80px;
     position:fixed;
     width: 100%;

--- a/nengo_viz/static/viz_top_toolbar.css
+++ b/nengo_viz/static/viz_top_toolbar.css
@@ -27,7 +27,7 @@
 
 #top_toolbar .nav {
     background: #eee;
-    box-shadow: 0 0 12px 1px rgba(87,87,87,0.2);
+    box-shadow: 0px 2px 4px 0px #999;
 }
 
 #filename{
@@ -43,7 +43,7 @@
     height: 300px;
     border: solid 1px #ccc;
     border-bottom-right-radius: 4px;
-    box-shadow: 6px 6px 12px 0px rgba(87,87,87,0.2);
+    box-shadow: 2px 2px 4px 0px #999;
     padding: 0.2em;
     background-color: #eee;
     z-index: 1000;


### PR DESCRIPTION
Someone commented that the new toolbar style was hard on the eyes because the light grey bleeds into the backgound. I think, this was mainly due to the light shadow which I made stronger now and which gives a better separation.