### PR TITLE
Fixing css styles for cursors

### DIFF
--- a/nengo_viz/static/main.css
+++ b/nengo_viz/static/main.css
@@ -19,18 +19,9 @@ body {
 .graph {
     background: #eeeeee;
 }
-    
+
 .line {
     fill: none;
     stroke: black;
-    stroke-width: 1.5px;    
-}
-
-* {
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
+    stroke-width: 1.5px;
 }

--- a/nengo_viz/static/viz.css
+++ b/nengo_viz/static/viz.css
@@ -29,12 +29,12 @@
 
 .graph text.graph_text {
     font-size: .8em;
-    cursor: default !important;
+    pointer-events: none;
 }
 
 .graph .axis text {
     font-size: .8em;
-    cursor: default !important;
+    pointer-events: none;
 }
 
 .graph .label {
@@ -42,9 +42,5 @@
     font-family: sans-serif;
     font-weight: normal;
     color: black;
-    cursor: ns-resize !important;
-}
-
-.graph .label:active {
-    cursor: ns-resize;
+    pointer-events: none;
 }

--- a/nengo_viz/static/viz.css
+++ b/nengo_viz/static/viz.css
@@ -7,7 +7,7 @@
     border: 1px solid #888888;
 }
 
-.graph text { 
+.graph text {
     cursor: default;
 }
 
@@ -18,7 +18,7 @@
 .graph .line {
     fill: none;
     stroke: black;
-    stroke-width: 1.5px;    
+    stroke-width: 1.5px;
 }
 
 .graph svg .axis path {
@@ -29,10 +29,12 @@
 
 .graph text.graph_text {
     font-size: .8em;
+    cursor: default !important;
 }
 
 .graph .axis text {
     font-size: .8em;
+    cursor: default !important;
 }
 
 .graph .label {
@@ -40,7 +42,7 @@
     font-family: sans-serif;
     font-weight: normal;
     color: black;
-    cursor: default;
+    cursor: ns-resize !important;
 }
 
 .graph .label:active {

--- a/nengo_viz/static/viz_menu.css
+++ b/nengo_viz/static/viz_menu.css
@@ -1,6 +1,6 @@
 .menu-item{
     font-size: .8em;
     text-align: left;
-    pointer-events: none;
+    cursor: default;
 }
 

--- a/nengo_viz/static/viz_menu.css
+++ b/nengo_viz/static/viz_menu.css
@@ -1,6 +1,6 @@
 .menu-item{
     font-size: .8em;
     text-align: left;
-    cursor: default;
+    cursor: pointer !important;
 }
 

--- a/nengo_viz/static/viz_menu.css
+++ b/nengo_viz/static/viz_menu.css
@@ -1,5 +1,6 @@
 .menu-item{
     font-size: .8em;
     text-align: left;
+    pointer-events: none;
 }
 

--- a/nengo_viz/static/viz_modal.css
+++ b/nengo_viz/static/viz_modal.css
@@ -2,6 +2,10 @@
     margin: 20px;
 }
 
+.modal-body input {
+    cursor: text !important;
+}
+
 .modal-body .tab-pane .dt-connections {
     margin-top: 20px;
 }
@@ -99,4 +103,5 @@ div.modal-backdrop {
 
 div.modal {
     z-index: 100000001;
+    cursor: default !important;
 }

--- a/nengo_viz/static/viz_netgraph.css
+++ b/nengo_viz/static/viz_netgraph.css
@@ -4,20 +4,21 @@
 .ensemble{
     stroke-width:1;
     }
-    
+
 g.node rect{
     stroke-width:1;
-    }  
+    }
 
 g.net rect{
     stroke-width:1;
-    }  
+    }
 
 .netgraph g text {
     text-anchor: middle;
     dominant-baseline: text-before-edge;
-    cursor: default;
-    }  
+    cursor: default !important;
+    }
+
 .netgraph g text:active {
     cursor: move;
 }
@@ -41,5 +42,5 @@ g.net rect{
 .netgraph g.passthrough text {
     text-anchor: middle;
     dominant-baseline: text-before-edge;
-    }    
+    }
 

--- a/nengo_viz/static/viz_slider.css
+++ b/nengo_viz/static/viz_slider.css
@@ -5,3 +5,7 @@
     border: 1px solid #888;
     border-radius: 4px;
 }
+
+input#value_in_field {
+    cursor: text !important;
+}

--- a/nengo_viz/static/viz_slidercontrol.js
+++ b/nengo_viz/static/viz_slidercontrol.js
@@ -26,8 +26,11 @@ VIZ.SliderControl = function(min, max) {
     this.guideline.style.margin = 'auto';
     this.container.appendChild(this.guideline);
 
-    this.handle = document.createElement('button');
-    this.handle.className = 'btn btn-default';
+
+    this.handle = document.createElement('div');
+    this.handle.classList.add('btn');
+    this.handle.classList.add('btn-default');
+    this.handle.innerHTML = 'n/a';
     this.handle.style.position = 'absolute';
     this.handle.style.height = '1.5em';
     this.handle.style.marginTop = '0.75em';
@@ -40,11 +43,6 @@ VIZ.SliderControl = function(min, max) {
     this.handle.style.transform = 'translate(0, -50%)';
     this.update_handle_pos(0);
     this.container.appendChild(this.handle);
-
-    this.valueDisplay = document.createElement('div');
-    this.valueDisplay.classList.add('value_display');
-    this.valueDisplay.innerHTML = 'n/a';
-    this.handle.appendChild(this.valueDisplay);
 
     interact(this.handle)
         .draggable({
@@ -126,8 +124,8 @@ VIZ.SliderControl.prototype.activate_type_mode = function() {
 
     this.type_mode = true;
 
-    this.valueDisplay.innerHTML = '<input id="value_in_field" style=" border:0; outline:0;"></input>';
-    var elem = this.valueDisplay.querySelector('#value_in_field')
+    this.handle.innerHTML = '<input id="value_in_field" style=" border:0; outline:0;"></input>';
+    var elem = this.handle.querySelector('#value_in_field')
     elem.value = this.format_value(this.value);
     elem.focus();
     elem.select();
@@ -154,9 +152,9 @@ VIZ.SliderControl.prototype.deactivate_type_mode = function(event) {
 
     this.type_mode = false;
 
-    $(this.value_display).off('keydown');
+    $(this.handle).off('keydown');
     this.handle.style.backgroundColor = '';
-    this.valueDisplay.innerHTML = this.format_value(this.value);
+    this.handle.innerHTML = this.format_value(this.value);
 };
 
 VIZ.SliderControl.prototype.handle_keypress = function(event) {
@@ -169,7 +167,7 @@ VIZ.SliderControl.prototype.handle_keypress = function(event) {
     var key = event.which;
 
     if (key == enter_keycode) {
-        var input = this.valueDisplay.querySelector('#value_in_field').value;
+        var input = this.handle.querySelector('#value_in_field').value;
         if (VIZ.is_num(input)) {
             this.deactivate_type_mode();
             this.set_value(parseFloat(input));
@@ -188,7 +186,7 @@ VIZ.SliderControl.prototype.get_handle_pos = function() {
 };
 
 VIZ.SliderControl.prototype.update_value_text = function(value) {
-    this.valueDisplay.innerHTML = this.format_value(value);
+    this.handle.innerHTML = this.format_value(value);
 };
 
 VIZ.SliderControl.prototype.format_value = function(value) {


### PR DESCRIPTION
Seems to work on firefox, chrome and safari as expected.  No selectable text on netgraph/components, text cursor in modals input boxes.  No interference on resizing. I found the magic 'pointer-events:none' css which makes this easier.