### PR TITLE
Removing the old slider when making a new one

### DIFF
--- a/nengo_viz/components/action.py
+++ b/nengo_viz/components/action.py
@@ -126,6 +126,11 @@ class CreateGraph(Action):
         cls = getattr(nengo_viz.components, self.type + 'Template')
         self.template = cls(self.obj, **kwargs)
 
+        # Remove any existing sliders associated with the same node
+        for component in self.net_graph.viz.components:
+            if isinstance(component, nengo_viz.components.slider.Slider) and component.node == self.obj: 
+                self.send('delete_graph', uid=component.uid)
+
         self.act_create_graph()
 
     def act_create_graph(self):

--- a/nengo_viz/components/action.py
+++ b/nengo_viz/components/action.py
@@ -128,7 +128,8 @@ class CreateGraph(Action):
 
         # Remove any existing sliders associated with the same node
         for component in self.net_graph.viz.components:
-            if isinstance(component, nengo_viz.components.slider.Slider) and component.node == self.obj: 
+            if (isinstance(component, nengo_viz.components.slider.Slider)
+                    and component.node is self.obj):
                 self.send('delete_graph', uid=component.uid)
 
         self.act_create_graph()
@@ -139,7 +140,8 @@ class CreateGraph(Action):
             self.graph_uid = self.net_graph.viz.viz.get_uid(self.template)
         else:
             self.net_graph.viz.viz.locals[self.graph_uid] = self.template
-            self.net_graph.viz.viz.default_labels[self.template] = self.graph_uid
+            self.net_graph.viz.viz.default_labels[self.template] = (
+                self.graph_uid)
         self.net_graph.config[self.template].x = self.x
         self.net_graph.config[self.template].y = self.y
         self.net_graph.config[self.template].width = self.width


### PR DESCRIPTION
This change has been made on the server side, because it wasn't possible to implement it on the client side since we do not have access to the parent 'node' on the client side.