### PR TITLE
No Spikes shown for an ensemble in direct mode

### DIFF
--- a/nengo_viz/components/raster.py
+++ b/nengo_viz/components/raster.py
@@ -14,14 +14,14 @@ class Raster(Component):
         self.obj = obj.neurons
         self.data = collections.deque()
         self.label = viz.viz.get_label(obj)
-        self.max_neurons = self.obj.size_out
+        self.max_neurons = obj.n_neurons
         if n_neurons is None:
-            n_neurons = min(self.obj.size_out, 10)
+            n_neurons = min(self.max_neurons, 10)
         self.n_neurons = n_neurons
 
     def add_nengo_objects(self, viz):
         with viz.model:
-            self.node = nengo.Node(self.gather_data, size_in=self.obj.size_out)
+            self.node = nengo.Node(self.gather_data, size_in=self.max_neurons)
             if 'spikes' in self.neuron_type.probeable:
                 self.conn = nengo.Connection(self.obj, self.node, synapse=None)
 
@@ -30,11 +30,8 @@ class Raster(Component):
         if 'spikes' in self.neuron_type.probeable:
             viz.model.connections.remove(self.conn)
 
-    def gather_data(self, t, x=None):
-        if x is None:
-            indices = []
-        else:
-            indices = np.nonzero(x[:self.n_neurons])[0]
+    def gather_data(self, t, x):
+        indices = np.nonzero(x[:self.n_neurons])[0]
         data = struct.pack('<f%dH' % len(indices), t, *indices)
         self.data.append(data)
 

--- a/nengo_viz/components/raster.py
+++ b/nengo_viz/components/raster.py
@@ -10,9 +10,7 @@ from nengo_viz.components.component import Component, Template
 class Raster(Component):
     def __init__(self, viz, config, uid, obj, n_neurons=None):
         super(Raster, self).__init__(viz, config, uid)
-        if getattr(obj, 'neuron_type') is not None:
-            type = (getattr(obj, 'neuron_type'))
-        self.neuron_type = type
+        self.neuron_type = obj.neuron_type
         self.obj = obj.neurons
         self.data = collections.deque()
         self.label = viz.viz.get_label(obj)

--- a/nengo_viz/components/raster.py
+++ b/nengo_viz/components/raster.py
@@ -10,6 +10,9 @@ from nengo_viz.components.component import Component, Template
 class Raster(Component):
     def __init__(self, viz, config, uid, obj, n_neurons=None):
         super(Raster, self).__init__(viz, config, uid)
+        if getattr(obj, 'neuron_type') is not None:
+            type = str(getattr(obj, 'neuron_type'))
+        self.neuron_type = type
         self.obj = obj.neurons
         self.data = collections.deque()
         self.label = viz.viz.get_label(obj)
@@ -20,12 +23,14 @@ class Raster(Component):
 
     def add_nengo_objects(self, viz):
         with viz.model:
-            self.node = nengo.Node(self.gather_data, size_in=self.obj.size_out)
-            self.conn = nengo.Connection(self.obj, self.node, synapse=None)
+            if self.neuron_type != 'Direct()':
+                self.node = nengo.Node(self.gather_data, size_in=self.obj.size_out)
+                self.conn = nengo.Connection(self.obj, self.node, synapse=None)
 
     def remove_nengo_objects(self, viz):
-        viz.model.connections.remove(self.conn)
-        viz.model.nodes.remove(self.node)
+        if self.neuron_type != 'Direct()':
+            viz.model.connections.remove(self.conn)
+            viz.model.nodes.remove(self.node)
 
     def gather_data(self, t, x):
         indices = np.nonzero(x[:self.n_neurons])[0]

--- a/nengo_viz/components/raster.py
+++ b/nengo_viz/components/raster.py
@@ -21,17 +21,20 @@ class Raster(Component):
 
     def add_nengo_objects(self, viz):
         with viz.model:
+            self.node = nengo.Node(self.gather_data, size_in=self.obj.size_out)
             if 'spikes' in self.neuron_type.probeable:
-                self.node = nengo.Node(self.gather_data, size_in=self.obj.size_out)
                 self.conn = nengo.Connection(self.obj, self.node, synapse=None)
 
     def remove_nengo_objects(self, viz):
+        viz.model.nodes.remove(self.node)
         if 'spikes' in self.neuron_type.probeable:
             viz.model.connections.remove(self.conn)
-            viz.model.nodes.remove(self.node)
 
-    def gather_data(self, t, x):
-        indices = np.nonzero(x[:self.n_neurons])[0]
+    def gather_data(self, t, x=None):
+        if x is None:
+            indices = []
+        else:
+            indices = np.nonzero(x[:self.n_neurons])[0]
         data = struct.pack('<f%dH' % len(indices), t, *indices)
         self.data.append(data)
 
@@ -50,4 +53,3 @@ class Raster(Component):
 class RasterTemplate(Template):
     cls = Raster
     config_params = dict(**Template.default_params)
-

--- a/nengo_viz/components/raster.py
+++ b/nengo_viz/components/raster.py
@@ -11,7 +11,7 @@ class Raster(Component):
     def __init__(self, viz, config, uid, obj, n_neurons=None):
         super(Raster, self).__init__(viz, config, uid)
         if getattr(obj, 'neuron_type') is not None:
-            type = str(getattr(obj, 'neuron_type'))
+            type = (getattr(obj, 'neuron_type'))
         self.neuron_type = type
         self.obj = obj.neurons
         self.data = collections.deque()
@@ -23,12 +23,12 @@ class Raster(Component):
 
     def add_nengo_objects(self, viz):
         with viz.model:
-            if self.neuron_type != 'Direct()':
+            if 'spikes' in self.neuron_type.probeable:
                 self.node = nengo.Node(self.gather_data, size_in=self.obj.size_out)
                 self.conn = nengo.Connection(self.obj, self.node, synapse=None)
 
     def remove_nengo_objects(self, viz):
-        if self.neuron_type != 'Direct()':
+        if 'spikes' in self.neuron_type.probeable:
             viz.model.connections.remove(self.conn)
             viz.model.nodes.remove(self.node)
 


### PR DESCRIPTION
This is a very temporary fix on the server side to prevent the exception being thrown right now. This code should later be removed from the server side and the fix should be made on the client side (this would require passing the information regarding the neuron type of an ensemble to the client).

The spike plot will still show up , but there will be no spikes displayed in direct mode